### PR TITLE
fix: android range and add external percentage label

### DIFF
--- a/.typesafe-i18n.json
+++ b/.typesafe-i18n.json
@@ -1,4 +1,4 @@
 {
    "adapter": "react",
-   "$schema": "https://unpkg.com/typesafe-i18n@5.26.0/schema/typesafe-i18n.json"
+   "$schema": "https://unpkg.com/typesafe-i18n@5.26.1/schema/typesafe-i18n.json"
 }

--- a/src/Components/Base/BaseRange/BaseRange.tsx
+++ b/src/Components/Base/BaseRange/BaseRange.tsx
@@ -12,8 +12,6 @@ type Props = {
     testID?: string
 }
 
-const SLIDER_OFFSET = 3
-
 export const BaseRange = ({
     value,
     onChange,
@@ -33,12 +31,8 @@ export const BaseRange = ({
                 let percentage = (markValue / maximumValue) * 100
                 let left: number | string = `${percentage}%`
                 let right: number | string = "auto"
-                if (percentage === 0) {
-                    left = SLIDER_OFFSET
-                }
-                if (percentage === 100) {
-                    left = "auto"
-                    right = SLIDER_OFFSET
+                if (percentage === 0 || percentage === 100) {
+                    return null
                 }
                 return (
                     <View

--- a/src/Screens/Flows/App/SendScreen/02-SelectAmountSendScreen/02-SelectAmountSendScreen.tsx
+++ b/src/Screens/Flows/App/SendScreen/02-SelectAmountSendScreen/02-SelectAmountSendScreen.tsx
@@ -41,7 +41,7 @@ type Props = NativeStackScreenProps<
 >
 
 export const SelectAmountSendScreen = ({ route }: Props) => {
-    const { token, initialRoute } = route.params
+    const { initialRoute, token } = route.params
 
     const theme = useTheme()
     const { LL } = useI18nContext()
@@ -295,7 +295,11 @@ export const SelectAmountSendScreen = ({ route }: Props) => {
                             <BaseCard>
                                 <BaseView flex={1}>
                                     <BaseText typographyFont="button">
-                                        {LL.SEND_BALANCE_PERCENTAGE()}
+                                        {LL.SEND_BALANCE_PERCENTAGE({
+                                            percentage: `${percentage.toFixed(
+                                                0,
+                                            )}%`,
+                                        })}
                                     </BaseText>
                                     <BaseView flexDirection="row">
                                         <BaseText
@@ -304,7 +308,6 @@ export const SelectAmountSendScreen = ({ route }: Props) => {
                                             {LL.SEND_RANGE_ZERO()}
                                         </BaseText>
                                         <BaseSpacer width={8} />
-                                        {/* TODO (Davide) (https://github.com/vechainfoundation/veworld-mobile/issues/766) understand how to add percentage value label */}
                                         <BaseRange
                                             value={percentage}
                                             onChange={

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -547,7 +547,7 @@ const en: BaseTranslation = {
     SEND_TOKEN_SUBTITLE: "Send your token",
     SEND_TOKEN_SELECT_ASSET: "Select the asset that you want to transfer",
     SEND_CURRENT_BALANCE: "Currency balance",
-    SEND_BALANCE_PERCENTAGE: "Balance percentage",
+    SEND_BALANCE_PERCENTAGE: "Balance percentage: {percentage: string}",
     SEND_RANGE_ZERO: "0%",
     SEND_RANGE_MAX: "MAX",
     SEND_INSUFFICIENT_BALANCE: "Insufficient balance",

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -1853,9 +1853,10 @@ type RootTranslation = {
 	 */
 	SEND_CURRENT_BALANCE: string
 	/**
-	 * B​a​l​a​n​c​e​ ​p​e​r​c​e​n​t​a​g​e
+	 * B​a​l​a​n​c​e​ ​p​e​r​c​e​n​t​a​g​e​:​ ​{​p​e​r​c​e​n​t​a​g​e​}
+	 * @param {string} percentage
 	 */
-	SEND_BALANCE_PERCENTAGE: string
+	SEND_BALANCE_PERCENTAGE: RequiredParams<'percentage'>
 	/**
 	 * 0​%
 	 */
@@ -4212,9 +4213,9 @@ Please, try again later.
 	 */
 	SEND_CURRENT_BALANCE: () => LocalizedString
 	/**
-	 * Balance percentage
+	 * Balance percentage: {percentage}
 	 */
-	SEND_BALANCE_PERCENTAGE: () => LocalizedString
+	SEND_BALANCE_PERCENTAGE: (arg: { percentage: string }) => LocalizedString
 	/**
 	 * 0%
 	 */


### PR DESCRIPTION
<img width="492" alt="Screenshot 2023-08-16 at 15 10 52" src="https://github.com/vechainfoundation/veworld-mobile/assets/5785838/bf2d61a7-1a1b-4069-a3b5-b41a43cc7df9">

I've found a solution removing external marks from the range component, and leaving just the central ones, it is still nice and we don't have the problem with android/ios and we don't even need to handle the slider width that varies between platforms.
apart from that, I've added the label for the percentage, we can't do it like the design because it's not that customizable, and it's the best component I've found.