### PR TITLE
1091 styleandroid not enough space for asset description in asset details

### DIFF
--- a/src/Screens/Flows/App/AssetDetailScreen/AssetDetailScreen.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/AssetDetailScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import React, { useEffect, useMemo } from "react"
-import { useBottomSheetModal, useTheme } from "~Hooks"
+import { useBottomSheetModal, useTheme, usePlatformBottomInsets } from "~Hooks"
 import {
     BaseIcon,
     BaseSpacer,
@@ -30,6 +30,7 @@ import {
     useAppDispatch,
     useAppSelector,
 } from "~Storage/Redux"
+import { isAndroid } from "~Utils/PlatformUtils/PlatformUtils"
 
 type Props = NativeStackScreenProps<
     RootStackParamListDiscover,
@@ -44,6 +45,9 @@ export const AssetDetailScreen = ({ route }: Props) => {
     const marketInfo = useAppSelector(state =>
         selectMarketInfoFor(token.symbol, state),
     )
+
+    const { calculateBottomInsets, tabBarAndroidBottomInsets } =
+        usePlatformBottomInsets()
 
     const { ref: QRCodeBottomSheetRef, onOpen: openQRCodeSheet } =
         useBottomSheetModal()
@@ -150,6 +154,13 @@ export const AssetDetailScreen = ({ route }: Props) => {
                                 </BaseText>
                             </>
                         )}
+                        <BaseSpacer
+                            height={
+                                isAndroid()
+                                    ? tabBarAndroidBottomInsets
+                                    : calculateBottomInsets
+                            }
+                        />
                     </BaseView>
                     <QRCodeBottomSheet ref={QRCodeBottomSheetRef} />
                 </>


### PR DESCRIPTION
Bottom space for asset description adjusted on both Android and Ios. Also Asset description has been trimmed.

Examples:

<div>
<div>
<img src=https://github.com/vechainfoundation/veworld-mobile/assets/17639359/54dde0cb-4318-4ad3-884f-0f001b943fe9 width=500/>
</div>
<br><br><br>
<div>
<img src=https://github.com/vechainfoundation/veworld-mobile/assets/17639359/dc0940d8-3ac4-49f9-8cab-f24258428571 width=500/>
</div>
</div>
