### PR TITLE
revert: animation delay

### DIFF
--- a/src/AnimatedSplashScreen.tsx
+++ b/src/AnimatedSplashScreen.tsx
@@ -13,7 +13,6 @@ import { PlatformUtils } from "~Utils"
 
 type Props = {
     playAnimation: boolean
-    animationDelay?: number
     useFadeOutAnimation?: boolean
     children: React.ReactNode
 }
@@ -34,7 +33,6 @@ type Props = {
  */
 export const AnimatedSplashScreen = ({
     playAnimation,
-    animationDelay,
     useFadeOutAnimation,
     children,
 }: Props): React.ReactElement => {
@@ -45,19 +43,15 @@ export const AnimatedSplashScreen = ({
 
     useEffect(() => {
         const startSplashScreenAnimation = () => {
-            loadingProgress.value = withTiming(
-                100,
-                { duration: useFadeOutAnimation ? 50 : 800 },
-                () => {
-                    runOnJS(setAnimationDone)(true)
-                },
-            )
+            loadingProgress.value = withTiming(100, { duration: 800 }, () => {
+                runOnJS(setAnimationDone)(true)
+            })
         }
 
         if (playAnimation) {
-            setTimeout(() => startSplashScreenAnimation(), animationDelay ?? 1)
+            startSplashScreenAnimation()
         }
-    }, [playAnimation, loadingProgress, animationDelay, useFadeOutAnimation])
+    }, [playAnimation, loadingProgress])
 
     const colorLayer = animationDone ? null : (
         <View style={[StyleSheet.absoluteFill, styles.colorLayer]} />

--- a/src/Components/Providers/SecurityProvider/SecurityProvider.tsx
+++ b/src/Components/Providers/SecurityProvider/SecurityProvider.tsx
@@ -11,7 +11,6 @@ import { SecurityDowngradeScreen } from "~Screens"
 import { AppBlockedScreen } from "~Screens/Flows/App/AppBlockedScreen"
 import { AnimatedSplashScreen } from "../../../AnimatedSplashScreen"
 import { AutoLogoutProvider } from "../AutoLogoutProvider"
-import { PlatformUtils } from "~Utils"
 import { AppInitState, useAppInitState } from "~Hooks"
 
 type Props = {
@@ -63,8 +62,7 @@ export const SecurityProvider = ({ children }: Props) => {
                 playAnimation={isSplashHidden || isBiometricsSucceeded}
                 useFadeOutAnimation={
                     isSplashHidden && initState !== AppInitState.INIT_STATE
-                }
-                animationDelay={PlatformUtils.isAndroid() ? 500 : undefined}>
+                }>
                 {children}
             </AnimatedSplashScreen>
         </AutoLogoutProvider>


### PR DESCRIPTION
Animation delay reverted for faster start up.

Example:


https://github.com/vechainfoundation/veworld-mobile/assets/17639359/285e4fc6-f600-4dfe-95c3-dafbd859c43c

