### PR TITLE
chore: fix sentry properties

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -73,6 +73,15 @@ jobs:
       - name: Rebuild Detox Framework
         run: yarn detox clean-framework-cache && yarn detox build-framework-cache
 
+      # Install sentry properties
+      - name: Sentry properties
+        uses: mobiledevops/secret-to-file-action@v1
+        with:
+            base64-encoded-secret: ${{ secrets.SENTRY_PROPERTIES }}
+            filename: "sentry.properties"
+            is-executable: false
+            working-directory: "./ios"
+
       # Start Metro Bundler
       - name: Start Metro Bundler
         run: REACT_APP_UI_LOG=false yarn react-native start &> metro-bundler.log &


### PR DESCRIPTION
- new repo secret SENTRY_PROPERTIES added
- secret is converted to file as part of e2e io workflow

![image](https://github.com/vechainfoundation/veworld-mobile/assets/1687730/572eb315-2c46-4c56-a0c1-02f1d9745480)

