### PR TITLE
fix: fixing gitleaks permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -4,6 +4,9 @@ on:
     push:
       branches:
         - 'master'
+permissions: 
+  contents: read # This is required for actions/checkout
+  pull-requests: write # This is required for pull request comments
 jobs:
   scan:
     name: gitleaks


### PR DESCRIPTION
Adding in new updated permissions for gitleaks, the issue was caused when we switched orgs. The base permissions are now more restricted so we need to specify what we need.