### PR TITLE
2303 Updated response schema type of CoinGecko endpoints

### DIFF
--- a/src/Api/Coingecko/endpoints.ts
+++ b/src/Api/Coingecko/endpoints.ts
@@ -38,7 +38,7 @@ const TokenInfoResponseSchema = z.object({
     }),
     description: z.record(z.string(), z.string()),
     links: z.object({
-        blockchain_site: z.array(z.string()),
+        blockchain_site: z.array(z.nullable(z.string())),
         homepage: z.array(z.string()),
     }),
     market_data: TokenInfoMarketDataSchema,


### PR DESCRIPTION
The endpoint response schema changed and in the `blockchain_site` array now there aren't only strings but also `null` values so I updated the type of the schema otherwise app throw an error and don't display the Price feed

![simulator_screenshot_9EE0CF26-1BB6-42A0-B80D-5F699B7D178E](https://github.com/user-attachments/assets/15e62d7b-69a4-4066-b85a-a621a8c7349a)

closes #2303 