### PR TITLE
2326 Fix navigation on go back after backup mnemonic

### DIFF
--- a/src/Navigation/Stacks/HomeStack.tsx
+++ b/src/Navigation/Stacks/HomeStack.tsx
@@ -26,7 +26,6 @@ import {
     ManageCustomTokenScreen,
     ManageTokenScreen,
     ObserveWalletScreen,
-    PrivacyScreen,
     SelectAmountSendScreen,
     SelectLedgerAccounts,
     SelectLedgerDevice,
@@ -89,7 +88,6 @@ export type RootStackParamListHome = {
         url: string
         ul?: boolean
     }
-    [Routes.SETTINGS_PRIVACY]: undefined
 }
 
 const { Navigator, Group, Screen } = createNativeStackNavigator<RootStackParamListHome>()
@@ -170,7 +168,6 @@ export const HomeStack = () => {
                     options={{ headerShown: false }}
                 />
                 <Screen name={Routes.BROWSER} component={InAppBrowser} options={{ headerShown: false }} />
-                <Screen name={Routes.SETTINGS_PRIVACY} component={PrivacyScreen} options={{ headerShown: false }} />
             </Group>
 
             <Group>

--- a/src/Screens/Flows/App/HomeScreen/Components/DeviceBackupModal/DeviceBackupBottomSheet.tsx
+++ b/src/Screens/Flows/App/HomeScreen/Components/DeviceBackupModal/DeviceBackupBottomSheet.tsx
@@ -7,7 +7,7 @@ import { SecurityAlertLight } from "~Assets"
 import { BaseBottomSheet, BaseButton, BaseSpacer, BaseText, BaseView } from "~Components"
 import { useBottomSheetModal, useCheckWalletBackup, useThemedStyles } from "~Hooks"
 import { useI18nContext } from "~i18n"
-import { RootStackParamListSettings, Routes, TabStackParamList } from "~Navigation"
+import { Routes, TabStackParamList } from "~Navigation"
 import {
     selectLastBackupRequestTimestamp,
     selectSelectedAccount,
@@ -21,7 +21,6 @@ export const DeviceBackupBottomSheet = () => {
     const { styles } = useThemedStyles(baseStyles)
     const { LL } = useI18nContext()
     const navigation = useNavigation<NativeStackNavigationProp<TabStackParamList>>()
-    const settingsNavigation = useNavigation<NativeStackNavigationProp<RootStackParamListSettings>>()
 
     const lastBackupRequestTimestamp = useAppSelector(selectLastBackupRequestTimestamp)
     const selectedAccount = useAppSelector(selectSelectedAccount)
@@ -89,9 +88,8 @@ export const DeviceBackupBottomSheet = () => {
 
     const goToPrivacyScreen = () => {
         onClose()
-        navigation.navigate("SettingsStack", { screen: Routes.SETTINGS })
-        navigation.navigate("SettingsStack", { screen: Routes.SETTINGS_PRIVACY })
-        settingsNavigation.navigate(Routes.SETTINGS_PRIVACY)
+        navigation.navigate("SettingsStack", { screen: Routes.SETTINGS, initial: true })
+        navigation.navigate("SettingsStack", { screen: Routes.SETTINGS_PRIVACY, initial: false })
     }
 
     return (


### PR DESCRIPTION
Fix navigation when user go to the backup screen via the backup  warning bottom sheet that broke the settings menu

iOS:

https://github.com/user-attachments/assets/5f994e1b-b00a-4bdb-89d6-2321a8d0caa4

Android:

[Android Simulator Screen.webm](https://github.com/user-attachments/assets/bdc7fc79-4372-4c1a-84c5-89cc02131f70)

closes #2326 