### PR TITLE
Fix app crash on Security upgrade in backup screen

### DIFF
--- a/src/Screens/Flows/App/SecurityUpgrade_V2/Standalone.components/MnemonicModalSheet.standalone.tsx
+++ b/src/Screens/Flows/App/SecurityUpgrade_V2/Standalone.components/MnemonicModalSheet.standalone.tsx
@@ -6,13 +6,13 @@ import {
     BaseView,
     BaseText,
     BaseSpacer,
-    MnemonicCard,
     BaseIcon,
     MnemonicAvoidScreenshotAlert,
 } from "~Components"
 import { useCopyClipboard, useTheme } from "~Hooks"
 import { useI18nContext } from "~i18n"
 import { Wallet } from "~Model"
+import { MnemonicCard } from "./MnemonicCard.standalone"
 
 type Props = {
     selectedWallet: Wallet | null


### PR DESCRIPTION
Fix the app crashing while performing the mnemonic backup on the security upgrade flow

[screenrecord_sec_upgrade_mnemonic.webm](https://github.com/user-attachments/assets/0b37fa16-dc51-4067-b364-8c38edb4e315)
