### PR TITLE
2270 New IPFS Provider

### DIFF
--- a/src/Utils/URIUtils/URIUtils.spec.ts
+++ b/src/Utils/URIUtils/URIUtils.spec.ts
@@ -205,7 +205,9 @@ describe("URIUtils", () => {
         })
 
         it("should return IPFS URL", () => {
-            expect(URIUtils.convertUriToUrl("ipfs://QmZ1YXJzZS5jb20")).toBe("https://api.vorj.app/ipfs/QmZ1YXJzZS5jb20")
+            expect(URIUtils.convertUriToUrl("ipfs://QmZ1YXJzZS5jb20")).toBe(
+                "https://api.gateway-proxy.vechain.org/ipfs/QmZ1YXJzZS5jb20",
+            )
         })
 
         it("should return arweave URL", () => {

--- a/src/Utils/URIUtils/URIUtils.ts
+++ b/src/Utils/URIUtils/URIUtils.ts
@@ -102,7 +102,7 @@ const convertUriToUrl = (uri: string) => {
 
             // Check cache for IPFS document
 
-            return `https://api.vorj.app/ipfs/${uriWithoutProtocol}`
+            return `https://api.gateway-proxy.vechain.org/ipfs/${uriWithoutProtocol}`
         case "ar":
             return `https://arweave.net/${uriWithoutProtocol}`
         default:


### PR DESCRIPTION
Changed the IPFS provider url to use the new proxy

https://github.com/user-attachments/assets/306a7b9a-9faf-497c-b52e-5170106599a1

closes #2270 
