### PR TITLE
ci: moving schedule for release automation to nightly

### DIFF
--- a/.github/workflows/release-overnight.yaml
+++ b/.github/workflows/release-overnight.yaml
@@ -12,7 +12,7 @@ on:
                 type: number
                 required: true
     schedule:
-    - cron: '0 12,16 * * 1-5'  # Runs at 12:00 and 16:00 UTC Monday through Friday - running twice for testing purposes
+    - cron: '0 23 * * 1-5'  # Runs at 23:00 UTC Monday through Friday 
 env:
     IOS_VERSION: ${{ vars.ios_version }}
     IOS_BUILD: ${{ vars.ios_build }}


### PR DESCRIPTION
Moving from twice daily to 11pm as the job is working fine the last two days.