### PR TITLE
chore: grey-out backup root and keystore wallets

### DIFF
--- a/src/Screens/Flows/App/PrivacyScreen/Components/DevicesBackupState.tsx
+++ b/src/Screens/Flows/App/PrivacyScreen/Components/DevicesBackupState.tsx
@@ -21,9 +21,9 @@ export const DevicesBackupState = ({ devices, onPress }: Props) => {
     const { LL } = useI18nContext()
 
     const handlePress = useCallback(
-        (device: BaseDevice) => {
-            if (device.type !== DEVICE_TYPE.LEDGER) {
-                onPress(device as LocalDevice)
+        (item: BaseDevice) => {
+            if (item.type === DEVICE_TYPE.LOCAL_MNEMONIC) {
+                onPress(item as LocalDevice)
             }
         },
         [onPress],
@@ -31,7 +31,7 @@ export const DevicesBackupState = ({ devices, onPress }: Props) => {
 
     const getStatusConfig = useCallback(
         (item: BaseDevice): StatusConfig => {
-            if (item.type === DEVICE_TYPE.LEDGER) {
+            if (item.type !== DEVICE_TYPE.LOCAL_MNEMONIC) {
                 return {
                     variant: "neutral",
                     statusText: LL.BD_CANT_BE_BACKED_UP(),


### PR DESCRIPTION
# Related Issue

Closes #2304 

# Description of Changes

- Make wallets imported through private key or keystore unable to be backed up (greyed out)

# Reviewer(s)

@Doublemme 

# UI/UX Changes

Imported through PK:
![IMG_2102](https://github.com/user-attachments/assets/ce071e28-1d28-406b-9e49-0198395a9887)


# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [x] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
