### PR TITLE
Removed android camera permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,8 +22,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <!-- TODO: enable again if error on prod build due to android permissions -->
+    <!-- <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" /> -->
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/src/Components/Reusable/NFTMedia/Hooks/useSaveMediaToPhotos.ts
+++ b/src/Components/Reusable/NFTMedia/Hooks/useSaveMediaToPhotos.ts
@@ -5,7 +5,6 @@ import ReactNativeBlobUtil, { FetchBlobResponse, StatefulPromise } from "react-n
 import { CameraRoll } from "@react-native-camera-roll/camera-roll"
 import { AlertUtils, PlatformUtils, debug } from "~Utils"
 import { NFTMedia } from "~Model"
-import { hasAndroidPermission } from "./Helpers"
 import { ERROR_EVENTS } from "~Constants"
 
 export const useSaveMediaToPhotos = (image?: NFTMedia, nftName: string = "VeWorld NFT") => {
@@ -28,9 +27,10 @@ export const useSaveMediaToPhotos = (image?: NFTMedia, nftName: string = "VeWorl
     const downloadImage = useCallback(async () => {
         if (!image) return
 
-        if (PlatformUtils.isAndroid() && !(await hasAndroidPermission())) {
-            return
-        }
+        //TODO(michael): if app crash when app built due to android missing permissions enable it again (also on manifest.xml)
+        // if (PlatformUtils.isAndroid() && !(await hasAndroidPermission())) {
+        //     return
+        // }
 
         try {
             // download image to device cache


### PR DESCRIPTION
Due to android changes on policy to enhance user privacy by limiting the number of apps with access to broad photo and video permissions we are going to remove the permissions for camera access