### PR TITLE
feat: add LOWER case as default for copyable addresses

### DIFF
--- a/src/Hooks/useCopyClipboard/useCopyClipboard.spec.ts
+++ b/src/Hooks/useCopyClipboard/useCopyClipboard.spec.ts
@@ -29,10 +29,10 @@ describe("useCopyClipboard", () => {
         const { result } = renderHook(() => useCopyClipboard())
 
         await act(async () => {
-            result.current.onCopyToClipboard(text.toUpperCase(), labelName)
+            result.current.onCopyToClipboard(text.toLowerCase(), labelName)
         })
 
-        expect(Clipboard.setStringAsync).toHaveBeenCalledWith(text.toUpperCase())
+        expect(Clipboard.setStringAsync).toHaveBeenCalledWith(text.toLowerCase())
         expect(showSuccessToast).toHaveBeenCalled()
     })
 
@@ -62,6 +62,6 @@ describe("useCopyClipboard", () => {
             result.current.onCopyToClipboard(text, labelName)
         })
 
-        expect(Clipboard.setStringAsync).toHaveBeenCalledWith(text.toUpperCase())
+        expect(Clipboard.setStringAsync).toHaveBeenCalledWith(text.toLowerCase())
     })
 })

--- a/src/Hooks/useCopyClipboard/useCopyClipboard.ts
+++ b/src/Hooks/useCopyClipboard/useCopyClipboard.ts
@@ -23,7 +23,7 @@ export const useCopyClipboard = () => {
 
     const onCopyToClipboard = useCallback(
         (text: string, labelName: string) => {
-            Clipboard.setStringAsync(text.toUpperCase())
+            Clipboard.setStringAsync(text.toLowerCase())
                 .then(async () => {
                     await HapticsService.triggerImpact({ level: "Light" })
                     showSuccessToast({


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes [#2524](https://github.com/vechain/veworld-mobile/issues/2524)

# Description of Changes

This PR adds a LOWER case functionality on account address copyable component. This is necessary to provide the same result on both extension and mobile when user's copy their address. No UI change is necessary.

<!-- Provide a detailed description of the changes made in this pull request. -->

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@grenos @Doublemme @mfrezzati

# UI/UX Changes



<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [x] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
