### PR TITLE
fix: show end of chart on token card

### DIFF
--- a/src/Screens/Flows/App/HomeScreen/Components/ListsView/Token/AnimatedChartCard.tsx
+++ b/src/Screens/Flows/App/HomeScreen/Components/ListsView/Token/AnimatedChartCard.tsx
@@ -10,7 +10,7 @@ import { Routes } from "~Navigation"
 import { BaseView } from "~Components"
 import HapticsService from "~Services/HapticsService"
 import { DEFAULT_LINE_CHART_DATA, getCoinGeckoIdBySymbol, useSmartMarketChart } from "~Api/Coingecko"
-import { B3TR } from "~Constants"
+import { B3TR, SCREEN_WIDTH } from "~Constants"
 import { VeB3trTokenCard } from "~Screens"
 
 const HEIGHT = 100
@@ -80,7 +80,7 @@ export const AnimatedChartCard = memo(({ tokenWithInfo, isEdit, isBalanceVisible
                     {!hideChart && (
                         <Animated.View style={animatedInnerCard}>
                             <LineChart.Provider data={chartData ?? DEFAULT_LINE_CHART_DATA}>
-                                <LineChart height={HEIGHT} yGutter={20}>
+                                <LineChart width={SCREEN_WIDTH - 32} height={HEIGHT} yGutter={20}>
                                     <LineChart.Path color={theme.colors.graphLine} width={2}>
                                         <LineChart.Gradient
                                             color={theme.colors.graphGradient}


### PR DESCRIPTION
# Related Issue

# Description of Changes

The end of the chart on the token cards was hidden

# Reviewer(s)

@Doublemme @mfrezzati 

# UI/UX Changes

before:

<img width="368" alt="Screenshot 2025-01-22 at 22 22 01" src="https://github.com/user-attachments/assets/b57da80a-0000-4bb3-a152-f339ce717930" />


after:

![Simulator Screenshot - iPhone 16 - 2025-01-22 at 22 08 28](https://github.com/user-attachments/assets/09875f4f-2ffa-48aa-a346-04ffa95079c1)




# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [x] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
