### PR TITLE
Fix: Edit wallet/account bottom sheet not adjusting position when keyboard opens

### DIFF
--- a/src/Screens/Flows/App/WalletManagement/WalletDetailScreen/components/EditWalletAccountBottomSheet/EditWalletAccountBottomSheet.tsx
+++ b/src/Screens/Flows/App/WalletManagement/WalletDetailScreen/components/EditWalletAccountBottomSheet/EditWalletAccountBottomSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescript/types"
-import { BaseBottomSheet, BaseButton, BaseSpacer, BaseText, BaseTextInput, BaseView } from "~Components"
+import { BaseBottomSheet, BaseBottomSheetTextInput, BaseButton, BaseSpacer, BaseText, BaseView } from "~Components"
 import { useI18nContext } from "~i18n"
 
 type Props = {
@@ -31,7 +31,7 @@ export const EditWalletAccountBottomSheet = React.forwardRef<BottomSheetModalMet
 
                         <BaseSpacer height={8} />
 
-                        <BaseTextInput testID="ChangeAlias_Input" value={alias} setValue={onChangeText} />
+                        <BaseBottomSheetTextInput testID="ChangeAlias_Input" value={alias} setValue={onChangeText} />
 
                         <BaseSpacer height={40} />
 


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes #2604 

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Updated the input component inside the bottomsheet in order to keep the bottomsheet visible with the keyboard opened

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@grenos @mfrezzati

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

https://github.com/user-attachments/assets/311f899d-6097-4418-b81f-2e6217720d33

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
