### PR TITLE
fix: remove sentry logs

### DIFF
--- a/src/Api/Coingecko/endpoints.ts
+++ b/src/Api/Coingecko/endpoints.ts
@@ -97,7 +97,6 @@ export const getTokenInfo = async (coinGeckoId?: string) => {
 
         return zodParsed
     } catch (e) {
-        error(ERROR_EVENTS.TOKENS, e)
         throw e
     }
 }


### PR DESCRIPTION
# Related Issue
no issue jsut a quick fix

# Description of Changes
Remove 2 specific logs that trigger a sentry issue. We have 1.4 million logs just from these 2 the last 14 days. 

obviously they are logs that are "over" triggered for various reasons and do not depict the actual functionaluty. 

# Reviewer(s)

@grenos @Doublemme @mfrezzati @BenMVeChain @hughlivingstone 

# UI/UX Changes

<img width="1469" alt="Screenshot 2025-02-14 at 21 39 08" src="https://github.com/user-attachments/assets/aa5a9ed4-a60f-42be-8d8a-fa5489b6a8e4" />

Thank you for contributing! 🎉
