### PR TITLE
fix: add refresh balance on inFocus event

### DIFF
--- a/src/Screens/Flows/App/HomeScreen/HomeScreen.tsx
+++ b/src/Screens/Flows/App/HomeScreen/HomeScreen.tsx
@@ -73,8 +73,8 @@ export const HomeScreen = () => {
     useFocusEffect(
         useCallback(() => {
             updateBalances()
-            updateSuggested()
-        }, [updateBalances, updateSuggested]),
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []),
     )
 
     const { LL } = useI18nContext()


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes # 
[2646](https://github.com/vechain/veworld-mobile/issues/2646)

# Description of Changes

This PR fixes a bug allowing user's balance to get updated after coming from WebView/InApp Browser. This was first noticed when a user was claiming B3TR and getting back to main/home view. Balance wasn't updated automatically but triggered after forced updated (dragging down). Now balances get updated every time home screen gets backed to be in focus. 

<!-- Provide a detailed description of the changes made in this pull request. -->

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@grenos @Doublemme @mfrezzati

# UI/UX Changes


https://github.com/user-attachments/assets/d5705a92-9598-46af-a971-a7cf0435bf44



<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [x] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
