### PR TITLE
fix: prevent multiple transactions when pressing confirm multiple times

### DIFF
--- a/src/Hooks/useTransactionScreen/useTransactionScreen.spec.ts
+++ b/src/Hooks/useTransactionScreen/useTransactionScreen.spec.ts
@@ -221,6 +221,46 @@ describe("useTransactionScreen", () => {
             expect(transaction).toBeInstanceOf(Transaction)
         }, 20000)
 
+        it("should only allow submitting one transaction at a time", async () => {
+            const { result } = renderHook(
+                () =>
+                    useTransactionScreen({
+                        clauses: vetTransaction1.body.clauses,
+                        onTransactionSuccess,
+                        onTransactionFailure,
+                        dappRequest: {
+                            isFirstRequest: true,
+                            method: "thor_sendTransaction",
+                            id: "1234",
+                            type: "in-app",
+                            message: [],
+                            options: {
+                                gas: 210000,
+                            },
+                            appUrl: "https://example.com",
+                            appName: "Example",
+                        },
+                    }),
+                {
+                    wrapper: TestWrapper,
+                },
+            )
+
+            await act(async () => {
+                result.current.onSubmit()
+                // The button should be disabled immediately after the first submission
+                expect(result.current.isDisabledButtonState).toBe(true)
+                result.current.onSubmit()
+            })
+
+            await waitFor(
+                () => {
+                    expect(onTransactionSuccess).toHaveBeenCalled()
+                },
+                { timeout: 10000 },
+            )
+        }, 20000)
+
         it("using ledger account should navigate", async () => {
             const accWithDevice = {
                 ...firstLedgerAccount,

--- a/src/Hooks/useTransactionScreen/useTransactionScreen.tsx
+++ b/src/Hooks/useTransactionScreen/useTransactionScreen.tsx
@@ -40,7 +40,6 @@ export const useTransactionScreen = ({
     const selectedAccount = useAppSelector(selectSelectedAccount)
 
     const [loading, setLoading] = useState(false)
-
     const [selectedFeeOption, setSelectedFeeOption] = useState(String(GasPriceCoefficient.REGULAR))
     const [isEnoughGas, setIsEnoughGas] = useState(true)
     const [txCostTotal, setTxCostTotal] = useState("0")
@@ -149,7 +148,6 @@ export const useTransactionScreen = ({
                 onTransactionFailure(e)
             }
         },
-
         [signTransaction, resetDelegation, LL, sendTransactionSafe, dispatch, onTransactionFailure],
     )
 
@@ -186,7 +184,6 @@ export const useTransactionScreen = ({
             onTransactionFailure(e)
         } finally {
             isSubmitting.current = false
-            // Don't setLoading(false) here if that's handled elsewhere
         }
     }, [
         selectedAccount,

--- a/src/Hooks/useTransactionScreen/useTransactionScreen.tsx
+++ b/src/Hooks/useTransactionScreen/useTransactionScreen.tsx
@@ -119,7 +119,6 @@ export const useTransactionScreen = ({
      */
     const signAndSendTransaction = useCallback(
         async (password?: string) => {
-            // Set loading state immediately to prevent multiple clicks
             setLoading(true)
 
             try {


### PR DESCRIPTION
# Related Issue

Closes #2724 

# Description of Changes

This prevents the sending multiple transactions if the Confirm button is clicked multiple times in quick succession. 

Created an `isSubmitting` ref that acts as a lock as to whether the submit can be called again.  it is also used as a conditional of `isDisabledButtonState` so the button is immediately disabled after the first click. 

I needed to use a ref rather than an existing state setting as state is set asynchronously.  This leads to another race condition that could allow(extremely fast) double clicking.  The ref creates a synchronous lock which makes it impossible.

# Reviewer(s)

@Doublemme

# UI/UX Changes

N/A

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
