### PR TITLE
fix: sentry ignore standard network errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,18 @@ const NavigationProvider = ({ children }) => {
 
 const SentryWrappedMain = Sentry.wrap(Main)
 
+/**
+ *  The network errors are extremly noisy and not actionable. If the phone does not have internet connection,
+ *  it will throw a network error which is a standard failure case.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/configuration/filtering/#ignore-errors
+ */
+const sentryIgnoreErrors = [
+    "WebSocket connection failed for host: wss://relay.walletconnect.org",
+    "AxiosError:",
+    "Error in Beat WebSocket",
+    "Error: Cannot find module 'react-native-localize'",
+]
 const SentryInitialedMain = () => {
     const sentryTrackingEnabled = useAppSelector(selectSentryTrackingEnabled)
     const [initializedSentry, setInitializedSentry] = React.useState(false)
@@ -237,6 +249,7 @@ const SentryInitialedMain = () => {
                 // We recommend adjusting this value in production.
                 tracesSampleRate: 1.0,
                 environment: process.env.NODE_ENV,
+                ignoreErrors: sentryIgnoreErrors,
             })
             setInitializedSentry(true)
         } else {


### PR DESCRIPTION
# Related Issue

# Description of Changes

This reduces the noisy network errors that we send to Sentry.  These are standard connection issues that are not actionable.  

# Reviewer(s)

@Doublemme

# UI/UX Changes

N/A

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
