### PR TITLE
refactor: added scenario for sending Max funds between wallet accounts

### DIFF
--- a/.maestro/send/send_max_funds.yaml
+++ b/.maestro/send/send_max_funds.yaml
@@ -1,0 +1,83 @@
+#send_max_funds
+appId: org.vechain.veworld.app
+tags:
+  - pull-request
+onFlowStart:
+  - runFlow: ../setup_reset/setupApp.yaml
+onFlowComplete:
+  - runFlow: ../setup_reset/resetApp.yaml
+---
+## User should be able to send max tokens - Send VET from Account 3 to Account 4
+- tapOn:
+    id: "HomeScreen_WalletManagementButton"
+- runFlow:
+      when:
+          platform: Android
+      commands:
+          - tapOn:
+                id: "DeviceBox"
+- runFlow:
+      when:
+          platform: iOS
+      commands:
+          - tapOn:
+                id: "Wallet_0"
+- tapOn:
+    id: "WalletDetailScreen_addAccountButton"
+- tapOn:
+    id: "BackButtonHeader-BaseIcon-backButton"
+- tapOn:
+    id: "BackButtonHeader-BaseIcon-backButton"
+- tapOn:
+    id: "AccountCard_changeAccountButton"
+- tapOn:
+    id: "selectAccount"
+    index: 2
+- tapOn:
+    id: "sendButton"
+- tapOn:
+    id: "VET"
+- tapOn:
+    id: "selectAccount"
+    index: 2
+- tapOn:
+    id: "next-button"
+- tapOn: "MAX"
+- tapOn: "MAX"
+- tapOn:
+    id: "next-button"
+- tapOn:
+    id: "confirm-send-button"
+- repeat:
+    while:
+      visible: "Insert your 6-digit PIN"
+    commands:
+      - tapOn: "1"
+- assertVisible: "My tokens"
+#Send VET back from Account 4 to Account 3
+- tapOn:
+    id: "AccountCard_changeAccountButton"
+- tapOn:
+    id: "selectAccount"
+    index: 3
+- tapOn:
+    id: "sendButton"
+- tapOn:
+    id: "VET"
+- tapOn:
+    id: "selectAccount"
+    index: 2
+- tapOn:
+    id: "next-button"
+- tapOn: "MAX"
+- tapOn: "MAX"
+- tapOn:
+    id: "next-button"
+- tapOn:
+    id: "confirm-send-button"
+- repeat:
+    while:
+      visible: "Insert your 6-digit PIN"
+    commands:
+      - tapOn: "1"
+- assertVisible: "My tokens"


### PR DESCRIPTION
# Related Issue

Closes #2779 

# Description of Changes

This PR adds a new Maestro test scenario for testing the maximum funds transfer functionality on Android devices. The test verifies the ability to transfer the entire balance from one account to another using the max button in the send flow.

# Reviewer(s)

 @Doublemme 

## Test Coverage
- Maximum funds transfer flow
- Balance transfer verification
- Transaction completion check

## Technical Details
- Added platform-specific tag for Android-only execution
- Uses the max button functionality in send flow
- Integrates with existing setup and reset flows

## Testing
- Test has been verified on Android  and iOS device simulators on local.
- Follows the existing Maestro test patterns

## Evidence
Attached recordings demonstrate the successful execution of the scenario on both Android and iOS platforms:

https://github.com/user-attachments/assets/c33fc825-c2a0-48d9-8397-db475d473326


https://github.com/user-attachments/assets/d4295bf1-0866-4b24-99b7-7be43c8cd574



