### PR TITLE
refactor: added scenario for discover screen connecting to VeBetterDao

### DIFF
--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -9,3 +9,4 @@ flows:
   - onboarding/*
   - userActivity/userActivity.yaml
   - universal_link/*
+  - discover/*

--- a/.maestro/discover/vebetterdao_verification.yaml
+++ b/.maestro/discover/vebetterdao_verification.yaml
@@ -1,0 +1,46 @@
+appId: org.vechain.veworld.app
+tags:
+  - pull-request
+onFlowStart:
+  - runFlow: ../setup_reset/setupApp.yaml
+onFlowComplete:
+  - runFlow: ../setup_reset/resetApp.yaml
+---
+# Test: Mobile QA Automation - Discover section - Verify that VeBetterDAO is listed, accessible and can be connected to wallet
+# Ticket: #2778
+
+- tapOn:
+    id: "discover-tab"
+- swipe:
+   from:
+     id: "__CAROUSEL_ITEM_0__"
+   direction: LEFT
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: "VeBetterDao_banner"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "__CAROUSEL_ITEM_1__"
+- tapOn:
+    text: "Login"
+    index: 0
+- tapOn: "CONFIRM"
+- tapOn: "CONNECT"
+- tapOn: "SIGN"
+- repeat:
+    while:
+      visible: "Insert your 6-digit PIN"
+    commands:
+      - tapOn: "1"
+- tapOn:
+    id: "closeButton"
+- tapOn:
+    id: "wallet-tab"
+- assertVisible:
+        id: "AccountCard_changeAccountButton"


### PR DESCRIPTION
# Related Issue

Closes #2778 

# Description of Changes
This PR implements automated testing for the VeBetterDAO discover section functionality using Maestro. The test suite verifies that VeBetterDAO is properly listed, accessible, and can be connected to a wallet.

## Test Coverage
The automation covers the following test scenarios:
1. **Discover Section Navigation**
   - Verifies access to the discover tab
   - Confirms VeBetterDAO banner visibility

2. **Platform-Specific Banner Interaction**
   - Android: Tests banner interaction using `VeBetterDao_banner` ID
   - iOS: Tests banner interaction using carousel item selection

3. **Wallet Connection Flow**
   - Login initiation
   - Connection confirmation
   - Transaction signing
   - PIN verification
   - Connection success verification

4. **Cleanup and Verification**
   - Proper session closure
   - Return to wallet tab
   - Account state verification

## Technical Details
- **Test File**: `.maestro/discover/vebetterdao_verification.yaml`
- **Dependencies**: Uses existing setup and reset flows
- **Platform Support**: Handles both Android and iOS specific interactions

## Test Flow
1. App setup and initialization
2. Discover section navigation
3. VeBetterDAO banner interaction
4. Wallet connection process
5. PIN verification

# Reviewer(s)
 @Doublemme

#Evidence

https://github.com/user-attachments/assets/47cb1d8f-3b10-468a-9490-06cea2e33218


https://github.com/user-attachments/assets/2f3f2d9b-614d-4920-b812-47e7f83886dc

