### PR TITLE
Fix :: iOS build runner setting by default macOS 15

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -26,7 +26,7 @@ on:
 jobs:
     build-release-ios:
         name: Build release for iOS
-        runs-on: macos-latest
+        runs-on: macos-15
         environment: ios-release
 
         # Proceed only if it's either not a release event or it's a pre-release.


### PR DESCRIPTION
# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Updated the runner for the production build and not only for the e2e tests and changed from `latest` to `macos-15` to force macos 15 with iOS sdk 18 and xcode 16

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@HiiiiD @hughlivingstone @paolampilla 

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

N/A

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
