### PR TITLE
2330 Add camera permission  check on dapp click

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
       <action android:name="android.intent.action.VIEW"/>
       <data android:scheme="https"/>
     </intent>
+    <intent>
+      <action android:name="android.media.action.IMAGE_CAPTURE" />
+    </intent>
   </queries>
   <application android:name=".MainApplication" android:allowBackup="false" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:largeHeap="true" android:networkSecurityConfig="@xml/network_security_config" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/BootTheme" tools:ignore="DataExtractionRules">
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:exported="true" android:launchMode="singleTask" android:screenOrientation="portrait" android:windowSoftInputMode="adjustPan" tools:ignore="LockedOrientationActivity,RedundantLabel">

--- a/src/Screens/Flows/App/DiscoverScreen/DiscoverScreen.tsx
+++ b/src/Screens/Flows/App/DiscoverScreen/DiscoverScreen.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from "react-native"
 import Animated, { useAnimatedRef } from "react-native-reanimated"
 import { BaseSpacer, BaseView, Layout } from "~Components"
 import { AnalyticsEvent } from "~Constants"
-import { useAnalyticTracking, useCameraPermissions, useFetchFeaturedDApps, useThemedStyles } from "~Hooks"
+import { useAnalyticTracking, useFetchFeaturedDApps, useThemedStyles } from "~Hooks"
 import { Routes } from "~Navigation"
 import {
     selectBookmarkedDapps,
@@ -28,10 +28,6 @@ export const DiscoverScreen: React.FC = () => {
 
     useFetchFeaturedDApps()
 
-    const { checkPermissions } = useCameraPermissions({
-        onCanceled: () => {},
-    })
-
     const animatedRef = useAnimatedRef<Animated.ScrollView>()
 
     const flatListRef = useRef(null)
@@ -42,10 +38,6 @@ export const DiscoverScreen: React.FC = () => {
     const { onDAppPress } = useDAppActions()
 
     const showFavorites = bookmarkedDApps.length > 0
-
-    useEffect(() => {
-        checkPermissions()
-    }, [checkPermissions])
 
     useEffect(() => {
         if (!hasOpenedDiscovery) {

--- a/src/Screens/Flows/App/DiscoverScreen/DiscoverScreen.tsx
+++ b/src/Screens/Flows/App/DiscoverScreen/DiscoverScreen.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from "react-native"
 import Animated, { useAnimatedRef } from "react-native-reanimated"
 import { BaseSpacer, BaseView, Layout } from "~Components"
 import { AnalyticsEvent } from "~Constants"
-import { useAnalyticTracking, useFetchFeaturedDApps, useThemedStyles } from "~Hooks"
+import { useAnalyticTracking, useCameraPermissions, useFetchFeaturedDApps, useThemedStyles } from "~Hooks"
 import { Routes } from "~Navigation"
 import {
     selectBookmarkedDapps,
@@ -17,7 +17,6 @@ import { useI18nContext } from "~i18n"
 import { Ecosystem, Favourites, Header, NewDapps } from "./Components"
 import { PopularTrendingDApps } from "./Components/PopularTrendingDApps"
 import { VeBetterDAOCarousel } from "./Components/VeBetterDAOCarousel"
-
 import { useDAppActions } from "./Hooks"
 
 export const DiscoverScreen: React.FC = () => {
@@ -29,6 +28,10 @@ export const DiscoverScreen: React.FC = () => {
 
     useFetchFeaturedDApps()
 
+    const { checkPermissions } = useCameraPermissions({
+        onCanceled: () => {},
+    })
+
     const animatedRef = useAnimatedRef<Animated.ScrollView>()
 
     const flatListRef = useRef(null)
@@ -39,6 +42,10 @@ export const DiscoverScreen: React.FC = () => {
     const { onDAppPress } = useDAppActions()
 
     const showFavorites = bookmarkedDApps.length > 0
+
+    useEffect(() => {
+        checkPermissions()
+    }, [checkPermissions])
 
     useEffect(() => {
         if (!hasOpenedDiscovery) {

--- a/src/Screens/Flows/App/DiscoverScreen/Hooks/useDAppActions.tsx
+++ b/src/Screens/Flows/App/DiscoverScreen/Hooks/useDAppActions.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { DiscoveryDApp, AnalyticsEvent } from "~Constants"
 import { addNavigationToDApp, useAppDispatch } from "~Storage/Redux"
-import { useAnalyticTracking, useVisitedUrls } from "~Hooks"
+import { useAnalyticTracking, useCameraPermissions, useVisitedUrls } from "~Hooks"
 import { useNavigation } from "@react-navigation/native"
 import { Routes } from "~Navigation"
 import { useNotifications } from "~Components"
@@ -12,18 +12,22 @@ export const useDAppActions = () => {
     const nav = useNavigation()
     const { addVisitedUrl } = useVisitedUrls()
     const { increaseDappCounter } = useNotifications()
+    const { checkPermissions } = useCameraPermissions({
+        onCanceled: () => {},
+    })
 
     const onDAppPress = useCallback(
-        (dapp: DiscoveryDApp) => {
+        async (dapp: DiscoveryDApp) => {
             track(AnalyticsEvent.DISCOVERY_USER_OPENED_DAPP, {
                 url: dapp.href,
             })
 
-            addVisitedUrl(dapp.href)
-
             if (dapp.veBetterDaoId) {
                 increaseDappCounter(dapp.veBetterDaoId)
+                await checkPermissions()
             }
+
+            addVisitedUrl(dapp.href)
 
             setTimeout(() => {
                 dispatch(addNavigationToDApp({ href: dapp.href, isCustom: dapp.isCustom ?? false }))
@@ -31,7 +35,7 @@ export const useDAppActions = () => {
 
             nav.navigate(Routes.BROWSER, { url: dapp.href })
         },
-        [addVisitedUrl, dispatch, increaseDappCounter, nav, track],
+        [addVisitedUrl, checkPermissions, dispatch, increaseDappCounter, nav, track],
     )
 
     return { onDAppPress }


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes #2330 

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Now when a user that opens VeWorld for the first time and click on a VBD dapp we request access to the camera permissions in order to avoid issues with the InAppbrowser dapps

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@HiiiiD @hughlivingstone @paolampilla 

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

[camera_pemissions_record.webm](https://github.com/user-attachments/assets/0ddd3826-6022-4790-bc10-0bf76da70a75)

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
