### PR TITLE
fix: do not reorder favorites by amount of navigations

### DIFF
--- a/src/Storage/Redux/Slices/Discovery.ts
+++ b/src/Storage/Redux/Slices/Discovery.ts
@@ -32,10 +32,6 @@ export const initialDiscoverState: DiscoveryState = {
     bannerInteractions: {},
 }
 
-const sortByAmountOfNavigations = (dapps: DiscoveryDApp[]) => {
-    return dapps.sort((a, b) => b.amountOfNavigations - a.amountOfNavigations)
-}
-
 const findByHref = (dapps: DiscoveryDApp[], href: string) => {
     return dapps.find(dapp => URIUtils.compareURLs(dapp.href, href))
 }
@@ -75,22 +71,17 @@ export const DiscoverySlice = createSlice({
                 if (existingDApp) {
                     existingDApp.amountOfNavigations += 1
                 }
-
-                //sort by amount of navigations
-                state.custom = sortByAmountOfNavigations(state.custom)
             } else {
                 const favourite = findByHref(state.favorites, payload.href)
 
                 if (favourite) {
                     favourite.amountOfNavigations += 1
-                    state.favorites = sortByAmountOfNavigations(state.favorites)
                 }
 
                 const featured = findByHref(state.featured, payload.href)
 
                 if (featured) {
                     featured.amountOfNavigations += 1
-                    state.featured = sortByAmountOfNavigations(state.featured)
                 }
             }
         },


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#119

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->
Do not auto reorder favorites based on interactions on the dapps

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @paolampilla 

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
