### PR TITLE
Fix :: disable sticky section headers in SelectAccountBottomSheet

### DIFF
--- a/src/Components/Reusable/SelectAccountBottomSheet/SelectAccountBottomSheet.tsx
+++ b/src/Components/Reusable/SelectAccountBottomSheet/SelectAccountBottomSheet.tsx
@@ -3,11 +3,12 @@ import { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescript/typ
 import React, { useCallback, useMemo } from "react"
 import { SectionListData } from "react-native"
 import { AccountCard, BaseBottomSheet, BaseIcon, BaseSpacer, BaseText, BaseView } from "~Components"
-import { COLORS } from "~Constants"
+import { COLORS, isSmallScreen } from "~Constants"
 import { useScrollableBottomSheet, useTheme } from "~Hooks"
 import { AccountWithDevice, WatchedAccount } from "~Model"
 import { useI18nContext } from "~i18n"
 import { SelectableAccountCard } from "../SelectableAccountCard"
+import { isIOS } from "~Utils/PlatformUtils/PlatformUtils"
 
 type Props = {
     /**
@@ -111,6 +112,10 @@ export const SelectAccountBottomSheet = React.forwardRef<BottomSheetModalMethods
                 return ["50%"]
             }
 
+            if (accounts.length === 5 && !isSmallScreen) {
+                return isIOS() ? ["65%"] : ["55%"]
+            }
+
             if (accounts.length < 6) {
                 return ["75%"]
             }
@@ -183,6 +188,8 @@ export const SelectAccountBottomSheet = React.forwardRef<BottomSheetModalMethods
                         )}
                         ItemSeparatorComponent={ItemSeparatorComponent.bind(null, { cardVersion })}
                         SectionSeparatorComponent={ItemSeparatorComponent.bind(null, { cardVersion })}
+                        {...flatListScrollProps}
+                        scrollEnabled
                     />
                 )}
             </BaseBottomSheet>

--- a/src/Components/Reusable/SelectAccountBottomSheet/SelectAccountBottomSheet.tsx
+++ b/src/Components/Reusable/SelectAccountBottomSheet/SelectAccountBottomSheet.tsx
@@ -172,6 +172,7 @@ export const SelectAccountBottomSheet = React.forwardRef<BottomSheetModalMethods
                         sections={sections}
                         keyExtractor={item => item.address}
                         renderSectionHeader={SectionHeader}
+                        stickySectionHeadersEnabled={false}
                         renderItem={({ item }) => (
                             <SelectableAccountCard
                                 account={item}
@@ -182,7 +183,6 @@ export const SelectAccountBottomSheet = React.forwardRef<BottomSheetModalMethods
                         )}
                         ItemSeparatorComponent={ItemSeparatorComponent.bind(null, { cardVersion })}
                         SectionSeparatorComponent={ItemSeparatorComponent.bind(null, { cardVersion })}
-                        {...flatListScrollProps}
                     />
                 )}
             </BaseBottomSheet>


### PR DESCRIPTION
# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Removed scroll props and sticky header on iOS for section list

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@HiiiiD 

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

https://github.com/user-attachments/assets/58347c24-e064-4975-a59c-c6d22272264c

[screen_record_section_list_bs.webm](https://github.com/user-attachments/assets/614b1ec2-5a08-4a9c-b729-11e30d997cbc)

### Small device 

<img width="320"  alt="Screenshot_1752505245" src="https://github.com/user-attachments/assets/9f2522e0-56d1-4c23-9058-903861cc5f58" />

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
