### PR TITLE
ci: chore: 3051 use latest version devicecloud workflow via @v1

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -133,7 +133,7 @@ jobs:
 
             - name: Test Android
               id: android-test
-              uses: devicecloud-dev/device-cloud-for-maestro@v1.2.2
+              uses: devicecloud-dev/device-cloud-for-maestro@v1
               with:
                   api-key: ${{ secrets.DCD_API_KEY }}
                   app-file: ${{ env.output_dir }}/app-release.apk

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -125,7 +125,7 @@ jobs:
             # Specifying version and device + retry on a temporary basis while devicecloud work on higher spec vm options.
             - name: Test iOS
               id: ios-test
-              uses: devicecloud-dev/device-cloud-for-maestro@v1.2.2
+              uses: devicecloud-dev/device-cloud-for-maestro@v1
               with:
                   api-key: ${{ secrets.DCD_API_KEY }}
                   app-file: ${{ env.APP_PATH }}


### PR DESCRIPTION
# Related Issue
3051
Closes #
3051
# Description of Changes
use latest devicecloud workflow via @v1 tag  in order to get outputs 
# Reviewer(s)

@grenos @Doublemme @ShaunKav 

---

Thank you for contributing! 🎉
