### PR TITLE
fix: fix b3tr conversion leaving dust

### DIFF
--- a/src/Constants/Theme/Colors.ts
+++ b/src/Constants/Theme/Colors.ts
@@ -139,6 +139,7 @@ export type Colors = {
         convertValueText: string
         swapIcon: string
         borderColor: string
+        errorText: string
     }
     activityCard: {
         time: string
@@ -453,6 +454,7 @@ const light: Colors = {
         convertValueText: COLORS.GREY_500,
         swapIcon: COLORS.GREY_600,
         borderColor: COLORS.GREY_200,
+        errorText: COLORS.RED_600,
     },
     activityCard: {
         time: COLORS.GREY_600,
@@ -673,6 +675,7 @@ const dark: Colors = {
         convertValueText: COLORS.GREY_300,
         swapIcon: COLORS.WHITE,
         borderColor: COLORS.DARK_PURPLE_DISABLED,
+        errorText: COLORS.RED_300,
     },
     activityCard: {
         time: COLORS.GREY_200,

--- a/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.spec.ts
+++ b/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.spec.ts
@@ -27,13 +27,13 @@ describe("useConvertBetterTokens", () => {
     })
     it("navigate to convert B3TR token to VOT3", async () => {
         const amount = "1"
+        const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
         const { result } = renderHook(() => useConvertBetterTokens(), { wrapper: TestWrapper })
         const { convertB3tr } = result.current
 
-        await act(async () => convertB3tr(amount))
+        await act(async () => convertB3tr(formattedAmount, amount))
 
         const spender = VOT3.address
-        const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
 
         const approveData = new abi.Function(abis.VeBetterDao.B3trAbis.approve).encode(spender, formattedAmount)
         const convertData = new abi.Function(abis.VeBetterDao.Vot3Abis.convertToVOT3).encode(formattedAmount)
@@ -60,12 +60,11 @@ describe("useConvertBetterTokens", () => {
 
     it("navigate to convert VOT3 to B3TR", async () => {
         const amount = "1"
+        const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
         const { result } = renderHook(() => useConvertBetterTokens(), { wrapper: TestWrapper })
         const { convertVot3 } = result.current
 
-        await act(async () => convertVot3(amount))
-
-        const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
+        await act(async () => convertVot3(formattedAmount, amount))
 
         const convertData = new abi.Function(abis.VeBetterDao.Vot3Abis.convertToB3TR).encode(formattedAmount)
 

--- a/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.ts
+++ b/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.ts
@@ -1,10 +1,10 @@
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
-import { ethers } from "ethers"
 import { useCallback } from "react"
 import { abi, Transaction } from "thor-devkit"
 import { abis, AnalyticsEvent } from "~Constants"
 import { useAnalyticTracking } from "~Hooks/useAnalyticTracking"
+import { useFormatFiat } from "~Hooks/useFormatFiat"
 import { useTokenWithCompleteInfo } from "~Hooks/useTokenWithCompleteInfo"
 import { RootStackParamListHome, Routes } from "~Navigation"
 import { selectNetworkVBDTokens, useAppSelector } from "~Storage/Redux"
@@ -16,18 +16,18 @@ export const useConvertBetterTokens = () => {
     const { B3TR, VOT3 } = useAppSelector(selectNetworkVBDTokens)
 
     const b3trWithCompleteInfo = useTokenWithCompleteInfo(B3TR)
+    const { formatLocale } = useFormatFiat()
 
     const buildB3trTxClauses = useCallback(
-        (amount: string | number): Transaction.Clause[] => {
+        (amount: string): Transaction.Clause[] => {
             const approveAbi = abis.VeBetterDao.B3trAbis.approve
             const conversionAbi = abis.VeBetterDao.Vot3Abis.convertToVOT3
             if (!conversionAbi || !approveAbi) throw new Error("Function abi not found for mint")
 
             const spender = VOT3.address
-            const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
 
-            const approveData = new abi.Function(approveAbi).encode(spender, formattedAmount)
-            const convertData = new abi.Function(conversionAbi).encode(formattedAmount)
+            const approveData = new abi.Function(approveAbi).encode(spender, amount)
+            const convertData = new abi.Function(conversionAbi).encode(amount)
 
             const clauses: Transaction.Clause[] = [
                 {
@@ -48,13 +48,11 @@ export const useConvertBetterTokens = () => {
     )
 
     const buildVot3TxClauses = useCallback(
-        (amount: string | number): Transaction.Clause[] => {
+        (amount: string): Transaction.Clause[] => {
             const functionAbi = abis.VeBetterDao.Vot3Abis.convertToB3TR
             if (!functionAbi) throw new Error("Function abi not found for mint")
 
-            const formattedAmount = ethers.utils.parseEther(amount.toString()).toString()
-
-            const convertData = new abi.Function(functionAbi).encode(formattedAmount)
+            const convertData = new abi.Function(functionAbi).encode(amount)
 
             const clauses: Transaction.Clause[] = [
                 {
@@ -72,38 +70,38 @@ export const useConvertBetterTokens = () => {
      * Helpers that create transaction to convert B3TR to VOT3 token
      */
     const convertB3tr = useCallback(
-        (amount: string | number) => {
+        (amount: string) => {
             const clauses = buildB3trTxClauses(amount)
             track(AnalyticsEvent.CONVERT_B3TR_VOT3, {
                 from: "B3TR",
                 to: "VOT3",
             })
             nav.replace(Routes.CONVERT_BETTER_TOKENS_TRANSACTION_SCREEN, {
-                amount: BigNutils(amount).toString,
+                amount: BigNutils(amount).toHuman(18).toTokenFormat_string(2, formatLocale),
                 transactionClauses: clauses,
                 token: b3trWithCompleteInfo,
             })
         },
-        [b3trWithCompleteInfo, buildB3trTxClauses, nav, track],
+        [b3trWithCompleteInfo, buildB3trTxClauses, formatLocale, nav, track],
     )
 
     /**
      * Helper that create transaction to convert VOT3 to B3TR token
      */
     const convertVot3 = useCallback(
-        (amount: string | number) => {
+        (amount: string) => {
             const clauses = buildVot3TxClauses(amount)
             track(AnalyticsEvent.CONVERT_B3TR_VOT3, {
                 from: "VOT3",
                 to: "B3TR",
             })
             nav.replace(Routes.CONVERT_BETTER_TOKENS_TRANSACTION_SCREEN, {
-                amount: BigNutils(amount).toString,
+                amount: BigNutils(amount).toHuman(18).toTokenFormat_string(2, formatLocale),
                 transactionClauses: clauses,
                 token: b3trWithCompleteInfo,
             })
         },
-        [b3trWithCompleteInfo, buildVot3TxClauses, nav, track],
+        [b3trWithCompleteInfo, buildVot3TxClauses, formatLocale, nav, track],
     )
 
     return {

--- a/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.ts
+++ b/src/Hooks/useConvertBetterTokens/useConvertBetterTokens.ts
@@ -4,11 +4,9 @@ import { useCallback } from "react"
 import { abi, Transaction } from "thor-devkit"
 import { abis, AnalyticsEvent } from "~Constants"
 import { useAnalyticTracking } from "~Hooks/useAnalyticTracking"
-import { useFormatFiat } from "~Hooks/useFormatFiat"
 import { useTokenWithCompleteInfo } from "~Hooks/useTokenWithCompleteInfo"
 import { RootStackParamListHome, Routes } from "~Navigation"
 import { selectNetworkVBDTokens, useAppSelector } from "~Storage/Redux"
-import { BigNutils } from "~Utils"
 
 export const useConvertBetterTokens = () => {
     const nav = useNavigation<NativeStackNavigationProp<RootStackParamListHome>>()
@@ -16,7 +14,6 @@ export const useConvertBetterTokens = () => {
     const { B3TR, VOT3 } = useAppSelector(selectNetworkVBDTokens)
 
     const b3trWithCompleteInfo = useTokenWithCompleteInfo(B3TR)
-    const { formatLocale } = useFormatFiat()
 
     const buildB3trTxClauses = useCallback(
         (amount: string): Transaction.Clause[] => {
@@ -70,38 +67,38 @@ export const useConvertBetterTokens = () => {
      * Helpers that create transaction to convert B3TR to VOT3 token
      */
     const convertB3tr = useCallback(
-        (amount: string) => {
+        (amount: string, formattedAmount: string) => {
             const clauses = buildB3trTxClauses(amount)
             track(AnalyticsEvent.CONVERT_B3TR_VOT3, {
                 from: "B3TR",
                 to: "VOT3",
             })
             nav.replace(Routes.CONVERT_BETTER_TOKENS_TRANSACTION_SCREEN, {
-                amount: BigNutils(amount).toHuman(18).toTokenFormat_string(2, formatLocale),
+                amount: formattedAmount,
                 transactionClauses: clauses,
                 token: b3trWithCompleteInfo,
             })
         },
-        [b3trWithCompleteInfo, buildB3trTxClauses, formatLocale, nav, track],
+        [b3trWithCompleteInfo, buildB3trTxClauses, nav, track],
     )
 
     /**
      * Helper that create transaction to convert VOT3 to B3TR token
      */
     const convertVot3 = useCallback(
-        (amount: string) => {
+        (amount: string, formattedAmount: string) => {
             const clauses = buildVot3TxClauses(amount)
             track(AnalyticsEvent.CONVERT_B3TR_VOT3, {
                 from: "VOT3",
                 to: "B3TR",
             })
             nav.replace(Routes.CONVERT_BETTER_TOKENS_TRANSACTION_SCREEN, {
-                amount: BigNutils(amount).toHuman(18).toTokenFormat_string(2, formatLocale),
+                amount: formattedAmount,
                 transactionClauses: clauses,
                 token: b3trWithCompleteInfo,
             })
         },
-        [b3trWithCompleteInfo, buildVot3TxClauses, formatLocale, nav, track],
+        [b3trWithCompleteInfo, buildVot3TxClauses, nav, track],
     )
 
     return {

--- a/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterBottomSheet.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterBottomSheet.tsx
@@ -84,8 +84,9 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     const onChangeText = useCallback(
         (newValue: string) => {
             const _newValue = removeInvalidCharacters(newValue)
+            const _realValue = ethers.utils.parseEther(_newValue || "0").toString()
             setInput(_newValue)
-            setRealValue(ethers.utils.parseEther(_newValue).toString())
+            setRealValue(_realValue)
 
             if (_newValue === "" || BigNutils(_newValue).isZero) {
                 if (timer.current) {
@@ -98,20 +99,16 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
                 return
             }
 
-            const balanceToHuman = BigNutils((isB3TRActive ? b3trTokenTotal : vot3TokenTotal) ?? "1").toHuman(
-                B3TR.decimals,
-            )
+            const balance = BigNutils((isB3TRActive ? b3trTokenTotal : vot3TokenTotal) ?? "1").toString
 
-            const controlValue = BigNutils(_newValue).addTrailingZeros(B3TR.decimals).toHuman(B3TR.decimals)
-
-            if (controlValue.isBiggerThan(balanceToHuman.toString)) {
+            if (BigNutils(_realValue).isBiggerThan(balance)) {
                 setIsError(true)
                 HapticsService.triggerNotification({ level: "Error" })
             } else {
                 setIsError(false)
             }
         },
-        [B3TR.decimals, b3trTokenTotal, isB3TRActive, removeInvalidCharacters, setInput, vot3TokenTotal],
+        [b3trTokenTotal, isB3TRActive, removeInvalidCharacters, setInput, vot3TokenTotal],
     )
 
     const onMaxAmountPress = useCallback(
@@ -139,11 +136,11 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     const onConvertPress = useCallback(() => {
         onClose()
         if (isB3TRActive) {
-            convertB3tr(realValue)
+            convertB3tr(realValue, input)
         } else {
-            convertVot3(realValue)
+            convertVot3(realValue, input)
         }
-    }, [convertB3tr, convertVot3, isB3TRActive, onClose, realValue])
+    }, [convertB3tr, convertVot3, input, isB3TRActive, onClose, realValue])
 
     return (
         <BaseBottomSheet

--- a/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterBottomSheet.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterBottomSheet.tsx
@@ -1,5 +1,6 @@
 import { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescript/types"
-import React, { useCallback, useMemo, useRef, useState } from "react"
+import { ethers } from "ethers"
+import { default as React, useCallback, useMemo, useRef, useState } from "react"
 import { StyleSheet } from "react-native"
 import { TouchableOpacity } from "react-native-gesture-handler"
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated"
@@ -26,6 +27,8 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     const [isSwapped, setIsSwapped] = useState(false)
     const [isSwapEnabled, setIsSwapEnabled] = useState(true)
     const [isError, setIsError] = useState(false)
+    // Real value that'll be sent to the blockchain
+    const [realValue, setRealValue] = useState("0")
 
     const { LL } = useI18nContext()
     const { styles, theme } = useThemedStyles(baseStyles)
@@ -72,6 +75,7 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     const resetStates = useCallback(() => {
         setIsSwapEnabled(true)
         setInput("")
+        setRealValue("0")
         cardPosition.value = 0
         setIsSwapped(false)
         setIsError(false)
@@ -81,6 +85,7 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
         (newValue: string) => {
             const _newValue = removeInvalidCharacters(newValue)
             setInput(_newValue)
+            setRealValue(ethers.utils.parseEther(_newValue).toString())
 
             if (_newValue === "" || BigNutils(_newValue).isZero) {
                 if (timer.current) {
@@ -110,9 +115,10 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     )
 
     const onMaxAmountPress = useCallback(
-        (maxAmount: string) => {
-            const _newValue = removeInvalidCharacters(maxAmount)
+        (realAmount: string, formattedAmount: string) => {
+            const _newValue = removeInvalidCharacters(formattedAmount)
             setInput(_newValue)
+            setRealValue(realAmount)
         },
         [removeInvalidCharacters, setInput],
     )
@@ -133,11 +139,11 @@ export const ConvertBetterBottomSheet = React.forwardRef<BottomSheetModalMethods
     const onConvertPress = useCallback(() => {
         onClose()
         if (isB3TRActive) {
-            convertB3tr(input)
+            convertB3tr(realValue)
         } else {
-            convertVot3(input)
+            convertVot3(realValue)
         }
-    }, [convertB3tr, convertVot3, input, isB3TRActive, onClose])
+    }, [convertB3tr, convertVot3, isB3TRActive, onClose, realValue])
 
     return (
         <BaseBottomSheet

--- a/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterCard.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterCard.tsx
@@ -17,7 +17,7 @@ type Props = {
     animatedStyle?: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>
     error?: boolean
     onSendAmountChange?: (amount: string) => void
-    onMaxAmountPress?: (maxAmount: string) => void
+    onMaxAmountPress?: (realAmount: string, formattedAmount: string) => void
 }
 
 export const ConvertBetterCard: React.FC<Props> = ({
@@ -63,8 +63,8 @@ export const ConvertBetterCard: React.FC<Props> = ({
     }, [token?.icon, token?.symbol])
 
     const handleOnMaxPress = useCallback(() => {
-        onMaxAmountPress?.(tokenTotalToHuman)
-    }, [onMaxAmountPress, tokenTotalToHuman])
+        onMaxAmountPress?.(tokenTotalBalance, tokenTotalToHuman)
+    }, [onMaxAmountPress, tokenTotalBalance, tokenTotalToHuman])
 
     return (
         <Animated.View style={animatedStyle}>

--- a/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterCard.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/Components/ConvertBetterCard.tsx
@@ -159,7 +159,7 @@ const baseStyles = (theme: ColorThemeType) =>
             color: theme.colors.convertBetterCard.convertValueText,
         },
         inputError: {
-            color: theme.colors.errorVariant.title,
+            color: theme.colors.convertBetterCard.errorText,
         },
         balanceContainer: {
             flex: 1,
@@ -169,7 +169,7 @@ const baseStyles = (theme: ColorThemeType) =>
             gap: 8,
         },
         totalBalanceError: {
-            color: theme.colors.errorVariant.title,
+            color: theme.colors.convertBetterCard.errorText,
         },
         maxButton: {
             borderColor: theme.colors.actionBanner.buttonBorder,


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#198

# Description of Changes
- Send max tokens instead of 2 decimals formatted string when converting b3tr -> vot3 or viceversa
- Fix color of input error
<!-- Provide a detailed description of the changes made in this pull request. -->

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->
[b3tr_vot3_convert.webm](https://github.com/user-attachments/assets/67164859-d946-4c1c-ae87-3593b5bb8ea1)
<img width="388" height="175" alt="image" src="https://github.com/user-attachments/assets/8e57340f-7aee-4b9f-bc0d-39d17fb2bd53" />
<img width="384" height="125" alt="image" src="https://github.com/user-attachments/assets/770e55dd-19d8-4712-a749-ab66317da67e" />

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
