### PR TITLE
fix: show VTHO on delegate fee acc selection

### DIFF
--- a/src/Components/Reusable/DelegationView/Components/AccountOption.tsx
+++ b/src/Components/Reusable/DelegationView/Components/AccountOption.tsx
@@ -69,6 +69,7 @@ export const AccountOption = ({ selectedDelegationAccount, children, accounts }:
                             return (
                                 <DelegateAccountCardRadio
                                     testID={"DELEGATE_ACCOUNT_CARD_RADIO"}
+                                    balanceToken={"VTHO"}
                                     account={item}
                                     onPress={handlePress}
                                     selected={item.address === selectedAccount?.address}


### PR DESCRIPTION
# Related Issue

Closes https://github.com/vechain/veworld-private/issues/199

# Description of Changes

Show VTHO on delegate fee acc selection

# Reviewer(s)

@HiiiiD  @Doublemme

# UI/UX Changes
<img width="331" height="650" alt="Screenshot 2025-07-24 at 09 21 42" src="https://github.com/user-attachments/assets/33da320f-b7f8-47d5-9153-526f7e29c158" />
<img width="346" height="644" alt="Screenshot 2025-07-24 at 09 21 51" src="https://github.com/user-attachments/assets/88cd35bf-122e-486e-8591-6b35531cb4c8" />


# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
