### PR TITLE
ci: #207 only do e2e on push to main or manual workflows

### DIFF
--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -13,8 +13,7 @@ on:
 
   pull_request_review:
     types: [submitted]
-    branches:
-      - "*"
+
   push:
     branches:
       - main
@@ -27,13 +26,15 @@ jobs:
   # defer build-and-test-<OS> until after approval 
   build-and-test-ios:
     if: >-
-      github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-ios.yml
     secrets: inherit
 
   build-and-test-android:
     if: >-
-      github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-android.yml
     secrets: inherit
 

--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
     branches:
       - "*"
+
+  pull_request_review:
+    types: [submitted]
+    branches:
+      - "*"
   push:
     branches:
       - main
@@ -22,13 +27,13 @@ jobs:
   # defer build-and-test-<OS> until after approval 
   build-and-test-ios:
     if: >-
-      github.event_name != 'pull_request' 
+      github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     uses: ./.github/workflows/e2e-ios.yml
     secrets: inherit
 
   build-and-test-android:
     if: >-
-      github.event_name != 'pull_request' 
+      github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     uses: ./.github/workflows/e2e-android.yml
     secrets: inherit
 

--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -19,11 +19,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # defer build-and-test-<OS> until after approval 
   build-and-test-ios:
+    if: >-
+      github.event_name != 'pull_request' 
     uses: ./.github/workflows/e2e-ios.yml
     secrets: inherit
 
   build-and-test-android:
+    if: >-
+      github.event_name != 'pull_request' 
     uses: ./.github/workflows/e2e-android.yml
     secrets: inherit
 

--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -2,10 +2,6 @@ name: Build, Test & Scan
 on:
   workflow_call:
 
-  schedule:
-    # Runs at 22:00 UTC every Sunday to Thursday
-    - cron: '0 22 * * 0-4'
-
   workflow_dispatch:
   pull_request:
     branches:


### PR DESCRIPTION
# Related Issue

excessive macos workflow runs 


# Description of Changes

ci workflow to only run on merge to main
# Reviewer(s)

@Doublemme @hughlivingstone @HiiiiD @BenMVeChain 
