### PR TITLE
ci: switch e2e to trigger on merge only

### DIFF
--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - "*"
 
-  pull_request_review:
-    types: [submitted]
-
   push:
     branches:
       - main
@@ -19,17 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # defer build-and-test-<OS> until after approval 
   build-and-test-ios:
-    if: >-
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-ios.yml
     secrets: inherit
 
   build-and-test-android:
-    if: >-
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-android.yml
     secrets: inherit


### PR DESCRIPTION
# Related Issue
https://github.com/vechain/veworld-mobile/pull/3156

Closes #

# Description of Changes

cicd workflo defer e2e to after merge / manual calls
# Reviewer(s)

@Doublemme @hughlivingstone @HiiiiD
