### PR TITLE
fix: add bot as user before fastlane

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -125,5 +125,7 @@ jobs:
               run: |
                   cd ios
                   git config --global url."https://${{ secrets.CI_USER_TOKEN }}@github.com".insteadOf https://github.com
+                  git config --local user.name  "github-actions[bot]"
+                  git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
                   cd fastlane
                   fastlane build_ci username:${{secrets.CI_USER}} token:${{secrets.CI_USER_TOKEN}} version:${{inputs.version}} build:${{inputs.build}}


### PR DESCRIPTION


# Description of Changes

Due to an update in the image on the GH runner the release job started failing so I've added a prefastlane step to declare the local user on the runner.

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
