### PR TITLE
fix: add more informative slack message for e2e test failures

### DIFF
--- a/.github/workflows/install-build-test-scan.yml
+++ b/.github/workflows/install-build-test-scan.yml
@@ -55,15 +55,13 @@ jobs:
           payload: |
             {
               "text": "${{ job.status }} scan ${{ needs.scan.result }}\n \
-                       iOS ${{ needs.build-and-test-ios.result || 'skipped' }} \
-                       url: ${{ needs.build-and-test-ios.outputs.resultUrl || 'N/A' }}\n \
-                       Android ${{ needs.build-and-test-android.result || 'skipped' }} \
-                       url: ${{ needs.build-and-test-android.outputs.resultUrl || 'N/A' }}\n \
+                       ${{ needs.build-and-test-ios.outputs.resultUrl && format('iOS {0} url: {1}', needs.build-and-test-ios.result || 'skipped', needs.build-and-test-ios.outputs.resultUrl) || '' }}\n \
+                       ${{ needs.build-and-test-android.outputs.resultUrl && format('Android {0} url: {1}', needs.build-and-test-android.result || 'skipped', needs.build-and-test-android.outputs.resultUrl) || '' }}\n \
                        Action Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" 
               "slack-message": "🚨🚨🚨 ${{ needs.build-and-test-ios.result != 'success' && needs.build-and-test-android.result != 'success' && 'Android and iOS' || (needs.build-and-test-android.result != 'success' && 'Android' || 'iOS') }} Nightly E2E Tests failed 🚨🚨🚨"
             }
       - name: FailureReportE2E2Slack
-        if:  github.ref == 'refs/heads/main' && (needs.build-and-test-ios.result != 'success' || needs.build-and-test-android.result != 'success' || needs.scan.result != 'success')  
+        if:  github.ref == 'refs/heads/main' && (needs.build-and-test-ios.result != 'success' || needs.build-and-test-android.result != 'success')  
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_VEWORLD_E2E_WEBHOOK }}
@@ -71,11 +69,9 @@ jobs:
           payload: |
             {
               "text": "${{ job.status }} scan ${{ needs.scan.result }}\n \
-                       iOS ${{ needs.build-and-test-ios.result || 'skipped' }} \
-                       url: ${{ needs.build-and-test-ios.outputs.resultUrl || 'N/A' }}\n \
-                       Android ${{ needs.build-and-test-android.result || 'skipped' }} \
-                       url: ${{ needs.build-and-test-android.outputs.resultUrl || 'N/A' }}\n \
-                       Commit: ${{ github.sha }} by ${{ github.actor }}\n \
+                       ${{ needs.build-and-test-ios.outputs.resultUrl && format('iOS {0} url: {1}', needs.build-and-test-ios.result || 'skipped', needs.build-and-test-ios.outputs.resultUrl) || '' }}\n \
+                       ${{ needs.build-and-test-android.outputs.resultUrl && format('Android {0} url: {1}', needs.build-and-test-android.result || 'skipped', needs.build-and-test-android.outputs.resultUrl) || '' }}\n \
+                       Commit: ${{ github.sha }} by *${{ github.actor }}*\n \
                        Action Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "slack-message": "🚨🚨🚨 ${{ needs.build-and-test-ios.result != 'success' && needs.build-and-test-android.result != 'success' && 'Android and iOS' || (needs.build-and-test-android.result != 'success' && 'Android' || 'iOS') }} E2E Tests failed on main 🚨🚨🚨"
             }


### PR DESCRIPTION
Closes #

# Description of Changes

The message will only fire if the E2E tests on iOS or Android have failed on main, not if the unit tests fail:

For an iOS test result failure the message will look like:

:gear: Result: success scan failure
 iOS fail url: http:www...
 Commit: ac0adc3f5a05f750724140ff4ee25605c7ebaf4f by HiiiiD
 Action Run: https://github.com/vechain/veworld-mobile/actions/runs/17606640269 @ September 10th, 2025 at 8:02 AM UTC
More details at https://console.devicecloud.dev/results
:rotating_light::rotating_light::rotating_light: iOS E2E Tests failed on main :rotating_light::rotating_light::rotating_light: (edited) 

The iOS and Android fail url line will only appear if the url is present. 

# Reviewer(s)


@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
