### PR TITLE
fix: fix query key for stargate users

### DIFF
--- a/src/Components/Reusable/AccountFiatBalance.tsx
+++ b/src/Components/Reusable/AccountFiatBalance.tsx
@@ -52,10 +52,10 @@ const AccountFiatBalance: React.FC<AccountFiatBalanceProps> = (props: AccountFia
 
     const { stargateNodes, isLoading: loadingNodes } = useUserNodes(accountAddress)
 
-    const { ownedStargateNfts: stargateNfts, isLoading: loadingStargateNfts } = useUserStargateNfts(
-        stargateNodes,
-        loadingNodes,
-    )
+    const { ownedStargateNfts: stargateNfts, isLoading: loadingStargateNfts } = useUserStargateNfts({
+        nodes: stargateNodes,
+        isLoadingNodes: loadingNodes,
+    })
 
     const totalStargateVet = useMemo(() => {
         return stargateNfts.reduce((acc, nft) => {

--- a/src/Hooks/Staking/useGroupedStakingData.ts
+++ b/src/Hooks/Staking/useGroupedStakingData.ts
@@ -19,7 +19,11 @@ export interface StakingGroup {
 
 export const useGroupedStakingData = (userAddress?: string) => {
     const { stargateNodes, isLoading: isLoadingNodes } = useUserNodes(userAddress)
-    const { ownedStargateNfts, isLoading: isLoadingNfts } = useUserStargateNfts(stargateNodes, isLoadingNodes)
+    const { ownedStargateNfts, isLoading: isLoadingNfts } = useUserStargateNfts({
+        nodes: stargateNodes,
+        address: userAddress,
+        isLoadingNodes,
+    })
 
     const stakingGroups = useMemo((): StakingGroup[] => {
         if (!stargateNodes.length) return []

--- a/src/Hooks/Staking/useUserStargateNfts.spec.ts
+++ b/src/Hooks/Staking/useUserStargateNfts.spec.ts
@@ -101,7 +101,7 @@ describe("useUserStargateNfts", () => {
     })
 
     it("should return empty array when no nodes are provided", () => {
-        const { result } = renderHook(() => useUserStargateNfts([], false), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: [], isLoadingNodes: false }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: preloadedState,
@@ -113,7 +113,7 @@ describe("useUserStargateNfts", () => {
     })
 
     it("should return NFTs data when nodes are provided", () => {
-        const { result } = renderHook(() => useUserStargateNfts(StargateNodeMocks, false), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: StargateNodeMocks, isLoadingNodes: false }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: preloadedState,
@@ -128,7 +128,7 @@ describe("useUserStargateNfts", () => {
     })
 
     it("should handle loading state when isLoadingNodes is true", () => {
-        const { result } = renderHook(() => useUserStargateNfts(StargateNodeMocks, true), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: StargateNodeMocks, isLoadingNodes: true }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: preloadedState,
@@ -142,7 +142,7 @@ describe("useUserStargateNfts", () => {
         const mockUseQuery = require("@tanstack/react-query").useQuery
         mockUseQuery.mockImplementation(() => mockQueryLoading)
 
-        const { result } = renderHook(() => useUserStargateNfts(StargateNodeMocks, false), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: StargateNodeMocks, isLoadingNodes: false }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: preloadedState,
@@ -157,7 +157,7 @@ describe("useUserStargateNfts", () => {
         const mockUseQuery = require("@tanstack/react-query").useQuery
         mockUseQuery.mockImplementation(() => mockQueryError)
 
-        const { result } = renderHook(() => useUserStargateNfts(StargateNodeMocks, false), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: StargateNodeMocks, isLoadingNodes: false }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: preloadedState,
@@ -171,7 +171,7 @@ describe("useUserStargateNfts", () => {
     })
 
     it("should handle network type changes correctly", () => {
-        const { result } = renderHook(() => useUserStargateNfts(StargateNodeMocks, false), {
+        const { result } = renderHook(() => useUserStargateNfts({ nodes: StargateNodeMocks, isLoadingNodes: false }), {
             wrapper: TestWrapper,
             initialProps: {
                 preloadedState: {

--- a/src/Hooks/useTotalFiatBalance/useTotalFiatBalance.ts
+++ b/src/Hooks/useTotalFiatBalance/useTotalFiatBalance.ts
@@ -45,10 +45,11 @@ export const useTotalFiatBalance = ({ account, enabled }: Args) => {
 
     const { stargateNodes, isLoading: loadingNodes } = useUserNodes(accountAddress, enabled)
 
-    const { ownedStargateNfts: stargateNfts, isLoading: loadingStargateNfts } = useUserStargateNfts(
-        stargateNodes,
-        loadingNodes,
-    )
+    const { ownedStargateNfts: stargateNfts, isLoading: loadingStargateNfts } = useUserStargateNfts({
+        nodes: stargateNodes,
+        isLoadingNodes: loadingNodes,
+        address: account.address,
+    })
 
     const totalStargateVet = useMemo(() => {
         return stargateNfts.reduce((acc, nft) => {

--- a/src/Screens/Flows/App/AssetDetailScreen/Components/StargateCarousel.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreen/Components/StargateCarousel.tsx
@@ -15,10 +15,10 @@ import { useBrowserTab } from "~Hooks/useBrowserTab"
 import { useI18nContext } from "~i18n"
 import { Routes } from "~Navigation"
 import { selectSelectedAccountAddress, useAppSelector } from "~Storage/Redux"
+import { AddressUtils } from "~Utils"
 import { BannersCarousel } from "../../HomeScreen/Components"
 import { NewStargateStakeCarouselItem } from "./NewStargateStakeCarouselItem"
 import { StargateCarouselItem } from "./StargateCarouselItem"
-import { AddressUtils } from "~Utils"
 
 enum StakingFilter {
     OWN = "own",
@@ -31,7 +31,11 @@ export const StargateCarousel = () => {
     const address = useAppSelector(selectSelectedAccountAddress)
 
     const { stargateNodes, isLoading: isLoadingNodes } = useUserNodes(address)
-    const { ownedStargateNfts, isLoading: isLoadingNfts } = useUserStargateNfts(stargateNodes, isLoadingNodes)
+    const { ownedStargateNfts, isLoading: isLoadingNfts } = useUserStargateNfts({
+        nodes: stargateNodes,
+        address,
+        isLoadingNodes: isLoadingNodes,
+    })
     const nav = useNavigation()
 
     const { navigateWithTab } = useBrowserTab()


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes #

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Update the query key of `useUserStargateNfts` in order to take into account the correct address and the node ids instead of the node length.
This fix solves an issue where with the new wallet switcher, the faster query was cached thus causing all of the others to return the same values as that

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
