### PR TITLE
fix: return to swap page from in app browser when closed

### DIFF
--- a/src/Navigation/Stacks/HomeStack.tsx
+++ b/src/Navigation/Stacks/HomeStack.tsx
@@ -124,7 +124,13 @@ export type RootStackParamListHome = {
     [Routes.BROWSER]: {
         url: string
         ul?: boolean
-        returnScreen?: Routes.DISCOVER | Routes.SETTINGS | Routes.HOME | Routes.ACTIVITY_STAKING | Routes.APPS
+        returnScreen?:
+            | Routes.DISCOVER
+            | Routes.SETTINGS
+            | Routes.HOME
+            | Routes.ACTIVITY_STAKING
+            | Routes.APPS
+            | Routes.SWAP
     }
     [Routes.SETTINGS_NETWORK]: undefined
     [Routes.SETTINGS_ADD_CUSTOM_NODE]: undefined

--- a/src/Screens/Flows/App/SwapScreen/SwapScreen.tsx
+++ b/src/Screens/Flows/App/SwapScreen/SwapScreen.tsx
@@ -70,7 +70,7 @@ export const SwapScreen = () => {
 
     const onDAppPress = useCallback(
         ({ href, custom }: { href: string; custom?: boolean }) => {
-            nav.navigate(Routes.BROWSER, { url: href })
+            nav.navigate(Routes.BROWSER, { url: href, returnScreen: Routes.SWAP })
 
             track(AnalyticsEvent.SWAPP_USER_OPENED_DAPP, {
                 url: href,


### PR DESCRIPTION
Closes #

Steps to reproduce on android:
* Go to swap section 
* select a swap app
* Close the browser

Fixes 

The browser now closes

# Reviewer(s)

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
