### PR TITLE
Fix :: ledger alias name when imported

### DIFF
--- a/src/Utils/AccountUtils/AccountUtils.spec.ts
+++ b/src/Utils/AccountUtils/AccountUtils.spec.ts
@@ -24,7 +24,10 @@ describe("AccountUtils", () => {
     })
 
     it("getAccountForIndex - should return the correct account", () => {
-        expect(AccountUtils.getAccountForIndex(0, TestHelpers.data.device1, 0)).toEqual(TestHelpers.data.account1D1)
+        expect(AccountUtils.getAccountForIndex(0, TestHelpers.data.device1, 0)).toEqual({
+            ...TestHelpers.data.account1D1,
+            alias: "Device 1 0",
+        })
     })
 
     it("getAccountForIndex - should throw when no xPub", () => {

--- a/src/Utils/AccountUtils/AccountUtils.ts
+++ b/src/Utils/AccountUtils/AccountUtils.ts
@@ -31,7 +31,7 @@ export const getAccountForIndex = (walletIndex: number, device: BaseDevice, acco
     const accountAddress = AddressUtils.getAddressFromXPub(device.xPub, walletIndex)
 
     return {
-        alias: nextAlias(accountId),
+        alias: nextAlias(accountId, device.alias),
         address: accountAddress,
         rootAddress: device.rootAddress,
         index: walletIndex,


### PR DESCRIPTION
# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Added the device alias name to the `getAccountForIndex` in order to generate the correct device name for ledger

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

## Onboarding flow

https://github.com/user-attachments/assets/0b8d9ed2-b614-4319-afa1-be50f9deb778

## Onboarded flow

https://github.com/user-attachments/assets/cf95fb3a-a97e-47e1-a699-81c0dad3705b

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
