### PR TITLE
feat: do not show animation on balance for low end devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ import {
     Rubik_Light,
 } from "~Assets"
 import { ERROR_EVENTS, typography } from "~Constants"
-import { AnalyticsUtils, info, URIUtils, DeviceUtils } from "~Utils"
+import { AnalyticsUtils, info, URIUtils } from "~Utils"
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
 import {
     NotificationsProvider,
@@ -68,8 +68,7 @@ import { InteractionProvider } from "~Components/Providers/InteractionProvider"
 import { FeatureFlaggedSmartWallet } from "./src/Components/Providers/FeatureFlaggedSmartWallet"
 import { KeyboardProvider } from "react-native-keyboard-controller"
 import { DeepLinksProvider } from "~Components/Providers/DeepLinksProvider"
-import { ReducedMotionConfig, ReduceMotion } from "react-native-reanimated"
-import { isAndroid } from "~Utils/PlatformUtils/PlatformUtils"
+import { DeviceProvider } from "~Components/Providers/DeviceProvider"
 
 const { fontFamily } = typography
 
@@ -146,17 +145,6 @@ const Main = () => {
     const networkType = selectedNetwork.type
     const nodeUrl = selectedNetwork.currentUrl
 
-    const [isLowEndDevice, setIsLowEndDevice] = useState(false)
-
-    useEffect(() => {
-        const checkDevicePerformance = async () => {
-            const isSlowDevice = isAndroid() && (await DeviceUtils.isSlowDevice())
-            setIsLowEndDevice(isSlowDevice)
-        }
-
-        checkDevicePerformance()
-    }, [])
-
     if (!fontsLoaded) return
     return (
         <GestureHandlerRootView style={{ flex: 1 }}>
@@ -175,15 +163,10 @@ const Main = () => {
                                             <WalletConnectContextProvider>
                                                 <BottomSheetModalProvider>
                                                     <InAppBrowserProvider>
-                                                        <ReducedMotionConfig
-                                                            mode={
-                                                                isLowEndDevice
-                                                                    ? ReduceMotion.Always
-                                                                    : ReduceMotion.System
-                                                            }
-                                                        />
                                                         <NotificationsProvider>
-                                                            <EntryPoint />
+                                                            <DeviceProvider>
+                                                                <EntryPoint />
+                                                            </DeviceProvider>
                                                         </NotificationsProvider>
                                                     </InAppBrowserProvider>
                                                 </BottomSheetModalProvider>

--- a/src/Components/Providers/DeviceProvider/DeviceProvider.tsx
+++ b/src/Components/Providers/DeviceProvider/DeviceProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from "react"
+import { ReducedMotionConfig, ReduceMotion } from "react-native-reanimated"
+import { DeviceUtils, PlatformUtils } from "~Utils"
+
+type DeviceContextProps = {
+    isLowEndDevice: boolean
+}
+const DeviceContext = createContext<DeviceContextProps>({ isLowEndDevice: false })
+
+export const DeviceProvider = ({ children }: PropsWithChildren) => {
+    const [isLowEndDevice, setIsLowEndDevice] = useState(false)
+
+    useEffect(() => {
+        const checkDevicePerformance = async () => {
+            const isSlowDevice = PlatformUtils.isAndroid() && (await DeviceUtils.isSlowDevice())
+            setIsLowEndDevice(isSlowDevice)
+        }
+
+        checkDevicePerformance()
+    }, [])
+
+    const memoized = useMemo(() => ({ isLowEndDevice }), [isLowEndDevice])
+
+    return (
+        <DeviceContext.Provider value={memoized}>
+            <ReducedMotionConfig mode={isLowEndDevice ? ReduceMotion.Always : ReduceMotion.System} />
+            {children}
+        </DeviceContext.Provider>
+    )
+}
+
+export const useDevice = () => useContext(DeviceContext)

--- a/src/Components/Providers/DeviceProvider/index.ts
+++ b/src/Components/Providers/DeviceProvider/index.ts
@@ -1,0 +1,1 @@
+export * from "./DeviceProvider"

--- a/src/Screens/Flows/App/BalanceScreen/Components/Balance/CurrentBalance.tsx
+++ b/src/Screens/Flows/App/BalanceScreen/Components/Balance/CurrentBalance.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react"
 import { StyleSheet, TouchableOpacity } from "react-native"
 import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanimated"
 import { BaseText } from "~Components"
+import { useDevice } from "~Components/Providers/DeviceProvider"
 import { COLORS } from "~Constants"
 import { useThemedStyles } from "~Hooks"
 import { useTotalFiatBalance } from "~Hooks/useTotalFiatBalance"
@@ -24,6 +25,7 @@ export const CurrentBalance = () => {
 
     const { styles } = useThemedStyles(baseStyles)
     const { renderedBalance } = useTotalFiatBalance({ address: account.address, enabled: true })
+    const { isLowEndDevice } = useDevice()
 
     const onPress = useCallback(() => {
         dispatch(setBalanceVisible(!isBalanceVisible))
@@ -45,7 +47,7 @@ export const CurrentBalance = () => {
                     {currencySymbol}
                 </BaseText>
                 <Animated.View style={styles.balance}>
-                    {splittedText.includes("•") ? (
+                    {splittedText.includes("•") || isLowEndDevice ? (
                         <Animated.Text
                             entering={FadeIn.duration(300)}
                             exiting={FadeOut.duration(300)}
@@ -81,6 +83,7 @@ const baseStyles = () =>
         },
         balance: {
             flexDirection: "row",
+            minHeight: 46,
         },
         currency: {
             height: 40,


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#414

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->
- Do not show animation on balance for low end devices
- Fix height when toggling off balance

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->


[no_animation.webm](https://github.com/user-attachments/assets/d8fb26e9-b756-46e3-9a37-4f2056d2aeee)

[balance_off_fix.webm](https://github.com/user-attachments/assets/49240562-033c-4771-a832-0e33b9e27f45)


# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
