### PR TITLE
fix(navigation): prevent Android activity details screen from closing

### DIFF
--- a/src/Navigation/Stacks/HistoryStack.tsx
+++ b/src/Navigation/Stacks/HistoryStack.tsx
@@ -62,7 +62,16 @@ export const HistoryStack = () => {
     return (
         <Navigator id="HistoryStack" screenOptions={{ headerShown: false, animationEnabled: isIOS() }}>
             <Screen name={Routes.HISTORY} component={ActivityScreen} options={{ headerShown: false }} />
-            <Screen name={Routes.ACTIVITY_DETAILS} component={ActivityDetailsScreen} options={{ headerShown: false }} />
+            <Screen
+                name={Routes.ACTIVITY_DETAILS}
+                component={ActivityDetailsScreen}
+                options={{
+                    headerShown: false,
+                    // Android-specific fix: Keeps HISTORY screen mounted to prevent Tab Navigator from unmounting
+                    // This preserves tab state when navigating to/from activity details
+                    detachPreviousScreen: isIOS() ? undefined : false,
+                }}
+            />
             <Screen
                 name={Routes.BROWSER}
                 component={InAppBrowser}


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

This PR implements a fix based on native prop on navigation (animation) to prevent Android history to trigger reset state thus unmounting details screen.

Closes https://github.com/vechain/veworld-private/issues/335

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

https://github.com/user-attachments/assets/34795dda-a824-43af-881c-7705d03dc84e

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [x] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
