### PR TITLE
476 - update background color of bottom sheets close icon

### DIFF
--- a/src/Components/Collectibles/CollectibleBottomSheet.tsx
+++ b/src/Components/Collectibles/CollectibleBottomSheet.tsx
@@ -152,7 +152,7 @@ const baseStyles = () =>
             position: "absolute",
             top: 12,
             right: 12,
-            backgroundColor: "rgba(0, 0, 0, 0.30)",
+            backgroundColor: "rgba(0, 0, 0, 0.50)",
             borderRadius: 100,
             padding: 10,
         },

--- a/src/Screens/Flows/App/AppsScreen/Components/Common/VbdCarousel/VbdCarouselBottomSheet.tsx
+++ b/src/Screens/Flows/App/AppsScreen/Components/Common/VbdCarousel/VbdCarouselBottomSheet.tsx
@@ -305,7 +305,7 @@ const baseStyles = (theme: ColorThemeType) =>
             position: "absolute",
             top: 12,
             right: 12,
-            backgroundColor: "rgba(0, 0, 0, 0.30)",
+            backgroundColor: "rgba(0, 0, 0, 0.50)",
             borderRadius: 100,
             padding: 10,
         },


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#476

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Increased opacity from 30% to 50% in close icon BG on both Apps and Collectibles

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

<img width="320" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-29 at 10 50 04" src="https://github.com/user-attachments/assets/c6438a39-84ab-4ffd-ae4b-df688bb75b74" />

<img width="320" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-29 at 10 50 17" src="https://github.com/user-attachments/assets/7775df79-cef3-4437-befd-d6f37eae5789" />

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
