### PR TITLE
479 -  adjusted tabs gap on balance screen

### DIFF
--- a/src/Components/Base/BaseSimpleTabs.tsx
+++ b/src/Components/Base/BaseSimpleTabs.tsx
@@ -53,8 +53,8 @@ export const BaseSimpleTabs = <TKeys extends string[] | readonly string[]>({
     }, [tabOffsets, selectedIndex, keys.length])
     if (keys.length !== labels.length) throw new Error("Keys and Labels should have the same length")
     return (
-        <BaseView style={[styles.root, rootStyle]} flexDirection="row" justifyContent="space-between" overflow="scroll">
-            <BaseView flexDirection="row" flex={1}>
+        <BaseView style={[styles.root, rootStyle]} flexDirection="row" justifyContent="space-between">
+            <BaseView flexDirection="row" flex={1} gap={8} overflow="scroll">
                 {keys.map((key, index) => {
                     const isSelected = selectedKey === key
                     const textColor = getTextColor(isSelected)


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#479

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Fixed missing gap in tabs on HomeScreen

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

<img width="320" height="2622" alt="simulator_screenshot_13658028-35EE-4DD3-BBF7-F870556FDBAD" src="https://github.com/user-attachments/assets/c8ce8718-cddc-413c-be45-11711e4febfe" />

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
