### PR TITLE
Fix token card sending the correct value of B3TR

### DIFF
--- a/src/Screens/Flows/App/AssetDetailScreenSheet/Components/AssetBalanceActivity/BalanceTab.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreenSheet/Components/AssetBalanceActivity/BalanceTab.tsx
@@ -97,7 +97,7 @@ export const BalanceTab = ({ token: _token }: Props) => {
                 )}
                 {showFiatBalance && <ValueContainer.DollarValue value={fiatBalance} testID="DOLLAR_VALUE" />}
             </ValueContainer>
-            <BalanceTabActions token={token} />
+            {b3trToken ? <BalanceTabActions token={b3trToken} /> : <BalanceTabActions token={token} />}
         </>
     )
 }


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#515

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->
- Send only B3TR in token card

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

[fix_balance_send.webm](https://github.com/user-attachments/assets/a53012ec-ca69-42a5-91c7-8a947a0b0d3c)



# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
