### PR TITLE
feat: add prefetch of all the periods

### DIFF
--- a/src/Api/Coingecko/hooks.ts
+++ b/src/Api/Coingecko/hooks.ts
@@ -186,12 +186,11 @@ export const useSmartMarketChartV2 = ({
     placeholderData?: MarketChartResponse
 }) => {
     return useQuery({
-        ...getMarketChartQueryOptions({
+        ...getSmartMarketChartV2QueryOptions({
             id,
             vs_currency,
             days,
         }),
-        queryKey: ["MARKET_CHART_V2", id, vs_currency, days],
         placeholderData,
         staleTime: getQueryCacheTime(true),
         refetchInterval: getRefetchIntevalTime(),

--- a/src/Screens/Flows/App/AssetDetailScreenSheet/AssetDetailScreenSheet.tsx
+++ b/src/Screens/Flows/App/AssetDetailScreenSheet/AssetDetailScreenSheet.tsx
@@ -51,13 +51,18 @@ export const AssetDetailScreenSheet = ({ route }: Props) => {
 
     const hasTokenChart = useMemo(() => SUPPORTED_CHART_TOKENS.has(token.symbol), [token.symbol])
 
+    const chartId = useMemo(
+        () => (hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined),
+        [hasTokenChart, token.symbol],
+    )
+
     const {
         data: chartData,
         isLoading,
         isFetching,
         isRefetching,
     } = useSmartMarketChartV2({
-        id: hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined,
+        id: chartId,
         vs_currency: currency,
         days: selectedItem.days,
     })
@@ -68,28 +73,28 @@ export const AssetDetailScreenSheet = ({ route }: Props) => {
         getSmartMarketChartV2QueryOptions({
             days: ASSET_CHART_PERIODS[1].days,
             vs_currency: currency,
-            id: hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined,
+            id: chartId,
         }),
     )
     usePrefetchQuery(
         getSmartMarketChartV2QueryOptions({
             days: ASSET_CHART_PERIODS[2].days,
             vs_currency: currency,
-            id: hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined,
+            id: chartId,
         }),
     )
     usePrefetchQuery(
         getSmartMarketChartV2QueryOptions({
             days: ASSET_CHART_PERIODS[3].days,
             vs_currency: currency,
-            id: hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined,
+            id: chartId,
         }),
     )
     usePrefetchQuery(
         getSmartMarketChartV2QueryOptions({
             days: ASSET_CHART_PERIODS[4].days,
             vs_currency: currency,
-            id: hasTokenChart ? getCoinGeckoIdBySymbol[token.symbol] : undefined,
+            id: chartId,
         }),
     )
 


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#527

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->
- Add prefetch of all the smart market charts

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->



[add_prefetch_of_charts.webm](https://github.com/user-attachments/assets/b966187b-9c31-4067-8a64-561c4c8a3c24)




# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉
