### PR TITLE
600 - Fix active filter autochange when contacts or address also in recent contacts

### DIFF
--- a/src/Components/Reusable/Send/02-Receiver/Components/KnownAddressesList.tsx
+++ b/src/Components/Reusable/Send/02-Receiver/Components/KnownAddressesList.tsx
@@ -36,7 +36,7 @@ const AnimatedSectionList = Animated.createAnimatedComponent(
 type Props = {
     selectedAddress?: string
     activeFilter?: FilterItem
-    onAddressChange: (address: string) => void
+    onAddressChange: (address: string, context: "recent" | "accounts" | "contacts") => void
 }
 
 export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressChange }: Props) => {
@@ -67,7 +67,13 @@ export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressCha
     }, [accounts])
 
     const renderItem = useCallback(
-        ({ item }: { item: AccountWithDevice | Contact | RecentContact }) => {
+        ({
+            item,
+            context,
+        }: {
+            item: AccountWithDevice | Contact | RecentContact
+            context: "recent" | "accounts" | "contacts"
+        }) => {
             const isSelected = AddressUtils.compareAddresses(selectedAddress, item.address)
             const isContact = "type" in item && item.type === ContactType.KNOWN
             return (
@@ -75,7 +81,7 @@ export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressCha
                     accountName={item.alias}
                     accountAddress={item.address}
                     onPress={({ accountAddress }) => {
-                        onAddressChange(accountAddress)
+                        onAddressChange(accountAddress, context)
                     }}
                     selected={isSelected}
                     isContact={isContact}
@@ -166,10 +172,11 @@ export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressCha
                 <Animated.FlatList
                     testID="Send_Receiver_Addresses_List_Recent_Contacts"
                     data={recentContacts}
+                    extraData={{ context: "recent" }}
                     style={styles.list}
                     contentContainerStyle={styles.listContentContainer}
                     keyExtractor={item => item.address}
-                    renderItem={renderItem}
+                    renderItem={({ item }) => renderItem({ item, context: "recent" })}
                     ItemSeparatorComponent={renderItemSeparator}
                     ListEmptyComponent={renderEmptyState}
                     showsVerticalScrollIndicator={false}
@@ -181,8 +188,9 @@ export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressCha
                 <AnimatedSectionList
                     testID="Send_Receiver_Addresses_List_Accounts"
                     sections={accountsSection}
+                    extraData={{ context: "accounts" }}
                     renderSectionHeader={renderSectionHeader}
-                    renderItem={renderItem}
+                    renderItem={({ item }) => renderItem({ item, context: "accounts" })}
                     contentContainerStyle={styles.listContentContainer}
                     style={styles.list}
                     keyExtractor={item => item.address}
@@ -200,10 +208,11 @@ export const KnownAddressesList = ({ selectedAddress, activeFilter, onAddressCha
                 <Animated.FlatList
                     testID="Send_Receiver_Addresses_List_Contacts"
                     data={contacts}
+                    extraData={{ context: "contacts" }}
                     style={styles.list}
                     contentContainerStyle={styles.listContentContainer}
                     keyExtractor={item => item.address}
-                    renderItem={renderItem}
+                    renderItem={({ item }) => renderItem({ item, context: "contacts" })}
                     ItemSeparatorComponent={renderItemSeparator}
                     ListEmptyComponent={renderEmptyState}
                     showsVerticalScrollIndicator={false}

--- a/src/Components/Reusable/Send/02-Receiver/ReceiverScreen.tsx
+++ b/src/Components/Reusable/Send/02-Receiver/ReceiverScreen.tsx
@@ -21,6 +21,8 @@ export const ReceiverScreen = () => {
 
     const [inputWalletAddress, setInputWalletAddress] = useState<string>("")
     const [listWalletAddresses, setListWalletAddresses] = useState<string>("")
+    const [addressChangeCtx, setAddressChangeCtx] = useState<"recent" | "accounts" | "contacts" | null>(null)
+
     const { styles } = useThemedStyles(baseStyles)
 
     const allAccounts = useAppSelector(selectAccounts)
@@ -33,22 +35,25 @@ export const ReceiverScreen = () => {
     const recentContacts = useAppSelector(selectRecentContacts)
 
     const activeFilter = useMemo(() => {
+        if (addressChangeCtx) return addressChangeCtx
         if (recentContacts.find(recentContact => AddressUtils.compareAddresses(recentContact.address, selectedAddress)))
             return "recent"
         if (accounts.find(account => AddressUtils.compareAddresses(account.address, selectedAddress))) return "accounts"
         if (contacts.find(contact => AddressUtils.compareAddresses(contact.address, selectedAddress))) return "contacts"
         return undefined
-    }, [selectedAddress, accounts, contacts, recentContacts])
+    }, [selectedAddress, accounts, contacts, recentContacts, addressChangeCtx])
 
     const handleAddressChange = useCallback(
-        (source: "input" | "list", address: string) => {
+        (source: "input" | "list", address: string, ctx?: "recent" | "accounts" | "contacts") => {
             if (source === "input") {
+                setAddressChangeCtx(null)
                 if (AddressUtils.compareAddresses(address, selectedAddress)) {
                     return
                 }
                 setInputWalletAddress(address)
                 setListWalletAddresses("")
             } else {
+                setAddressChangeCtx(ctx ?? null)
                 setListWalletAddresses(address)
                 setInputWalletAddress("")
             }
@@ -82,7 +87,7 @@ export const ReceiverScreen = () => {
                 <KnownAddressesList
                     activeFilter={activeFilter}
                     selectedAddress={listWalletAddresses}
-                    onAddressChange={address => handleAddressChange("list", address)}
+                    onAddressChange={(address, ctx) => handleAddressChange("list", address, ctx)}
                 />
             </SendContent.Container>
             <SendContent.Footer>


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#600

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Fixed an issue when selecting an element from the contacts/accounts list and it was also into the recent contacts the recent contacts filter was automatically selected.

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

https://github.com/user-attachments/assets/e7cddd8a-6b24-463d-be7d-ca10df4be6bd

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced address receiver functionality with improved context tracking. The system now identifies the source of each address selection—whether from recent items, saved accounts, or contact lists—to enable more intelligent address management and support context-aware address workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->