### PR TITLE
feat: add legacy connected app when creating a temp session

### DIFF
--- a/src/Hooks/useLoginSession/useLoginSession.ts
+++ b/src/Hooks/useLoginSession/useLoginSession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react"
 import { CertificateRequest, TransactionRequest, TypeDataRequest } from "~Model"
 import {
+    addConnectedDiscoveryApp,
     addSession,
     selectSelectedAccountOrNull,
     selectSelectedNetwork,
@@ -37,6 +38,13 @@ export const useLoginSession = () => {
                     url: request.appUrl,
                     name: request.appName,
                     replaceable: true,
+                }),
+            )
+            dispatch(
+                addConnectedDiscoveryApp({
+                    connectedTime: Date.now(),
+                    href: new URL(request.appUrl).hostname,
+                    name: request.appName,
                 }),
             )
         },


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes vechain/veworld-private#598

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->
- Create connected discovery dapp for temp sessions if created with legacy methods

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->



[add_legacy_connected_apps.webm](https://github.com/user-attachments/assets/9468e20a-13bc-4c09-8676-830d2968bd3c)




# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Sessions now automatically capture and record connected discovery app information, including connection timestamp and app name for improved session tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->