### PR TITLE
feat(receive-tab): show avatar on QR code with circular shape

### DIFF
--- a/src/Components/Reusable/BottomSheets/SendReceiveBottomSheet/ReceiveTab.tsx
+++ b/src/Components/Reusable/BottomSheets/SendReceiveBottomSheet/ReceiveTab.tsx
@@ -1,16 +1,20 @@
 import picasso from "@vechain/picasso"
-import React, { useCallback, useState } from "react"
+import * as FileSystem from "expo-file-system"
+import React, { useCallback, useMemo, useState } from "react"
 import { Share, StyleSheet } from "react-native"
 import QRCode from "react-native-qrcode-svg"
 import { BaseButton, BaseIcon, BaseSpacer, BaseText, BaseView } from "~Components/Base"
 import { COLORS } from "~Constants"
 import { useThemedStyles } from "~Hooks"
 import { useCopyClipboard } from "~Hooks/useCopyClipboard"
+import { useVetDomainsAvatar } from "~Hooks/useVetDomainsAvatar"
 import { useVns } from "~Hooks/useVns"
 import { useI18nContext } from "~i18n"
 import { selectSelectedAccount, useAppSelector } from "~Storage/Redux"
-import { AddressUtils } from "~Utils"
+import { AddressUtils, URIUtils } from "~Utils"
 import { OnlyVechainNetworkAlert } from "./OnlyVechainNetworkAlert"
+
+const LOGO_SIZE = 56
 
 export const ReceiveTab = () => {
     const { LL } = useI18nContext()
@@ -21,6 +25,18 @@ export const ReceiveTab = () => {
         name: "",
         address: selectedAccount.address,
     })
+
+    const { data: vetDomainsPfp } = useVetDomainsAvatar({ address: selectedAccount.address })
+
+    const avatarUri = useMemo(() => {
+        if (selectedAccount.profileImage) {
+            return `${FileSystem.documentDirectory}${selectedAccount.profileImage.uri}`
+        }
+        if (vetDomainsPfp) {
+            return URIUtils.convertUriToUrl(vetDomainsPfp)
+        }
+        return undefined
+    }, [selectedAccount.profileImage, vetDomainsPfp])
 
     const [accountCopied, setAccountCopied] = useState(false)
 
@@ -55,10 +71,14 @@ export const ReceiveTab = () => {
                         value={selectedAccount.address}
                         size={200}
                         quietZone={10}
-                        logoSize={56}
+                        logoSize={LOGO_SIZE}
                         logoBackgroundColor="transparent"
-                        logoSVG={picasso(selectedAccount.address.toLowerCase())}
-                        logoBorderRadius={8}
+                        {...(avatarUri
+                            ? { logo: { uri: avatarUri }, logoBorderRadius: LOGO_SIZE / 2 }
+                            : {
+                                  logoSVG: picasso(selectedAccount.address.toLowerCase()),
+                                  logoBorderRadius: 8,
+                              })}
                     />
                 </BaseView>
                 <BaseSpacer height={16} />


### PR DESCRIPTION
In This PR:

- Add avatar support (local profileImage and VetDomains)
- Use circular logoBorderRadius when avatar is set
- Fall back to Picasso with original square-ish border radius

# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

Closes # https://github.com/vechain/veworld-private/issues/563

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes
<img width="525" height="1061" alt="Screenshot 2025-12-16 at 18 29 53" src="https://github.com/user-attachments/assets/222b798b-0d33-4d21-8908-9dca7c0b3316" />

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [x] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR codes in the Receive tab now display your profile picture as the logo instead of a generic icon. Your local profile image is prioritized; if unavailable, your Vet Domains avatar is displayed for enhanced visual identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->