### PR TITLE
Fix :: fiat value on step 3 send flow

### DIFF
--- a/src/Components/Reusable/Send/01-Amount/Hooks/useSendAmountInput.ts
+++ b/src/Components/Reusable/Send/01-Amount/Hooks/useSendAmountInput.ts
@@ -22,7 +22,14 @@ const getMaxDecimals = (args: { kind: "fiat" } | { kind: "token"; decimals: numb
     return args.decimals
 }
 
-export const truncateToMaxDecimals = (value: string, opts: Parameters<typeof getMaxDecimals>[0]) => {
+const fillWithZeros = (value: string, maxDecimals: number) => {
+    return value.padEnd(maxDecimals, "0")
+}
+
+export const truncateToMaxDecimals = (
+    value: string,
+    opts: Parameters<typeof getMaxDecimals>[0] & { fillWithZeros?: boolean },
+) => {
     const parts = value.split(/([.,])/)
     if (parts.length >= 3) {
         const integerPart = parts[0]
@@ -30,7 +37,13 @@ export const truncateToMaxDecimals = (value: string, opts: Parameters<typeof get
         const decimalPart = parts[2]
         const maxDecimals = getMaxDecimals(opts)
 
-        return `${integerPart}${separator}${decimalPart.substring(0, maxDecimals)}`
+        const decimalValue = decimalPart.substring(0, maxDecimals)
+
+        return `${integerPart}${separator}${
+            decimalValue.length < maxDecimals && opts.fillWithZeros
+                ? fillWithZeros(decimalValue, maxDecimals)
+                : decimalValue
+        }`
     }
     return value
 }

--- a/src/Components/Reusable/Send/03-SummarySend/Components/TokenReceiverCard.tsx
+++ b/src/Components/Reusable/Send/03-SummarySend/Components/TokenReceiverCard.tsx
@@ -58,7 +58,7 @@ export const TokenReceiverCard = () => {
         const [integerPart, decimalPart] = truncateToMaxDecimals(
             isInputInFiat ? flowState.fiatAmount ?? "0" : nextFiatAmount.value ?? "0",
             // Always use 2 decimals for converted value
-            { kind: "fiat" },
+            { kind: "fiat", fillWithZeros: true },
         ).split(/[.,]/)
 
         const formatter = getNumberFormatter({


### PR DESCRIPTION
# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

fixed small issue with fiat value on send flow

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone @HiiiiD

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fiat value display now updates correctly when switching between token and fiat input modes so the shown amount always matches the selected input.
* **Enhancements**
  * Fiat amounts are rendered with consistent decimal precision (trailing zeros added when needed) for clearer, uniform presentation.
* **Stability**
  * UI now reliably recomputes displayed fiat values when input mode changes to prevent stale values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->