### PR TITLE
fix: normalize delegation url protocol casing

### DIFF
--- a/src/Hooks/useDelegation/useDelegation.spec.ts
+++ b/src/Hooks/useDelegation/useDelegation.spec.ts
@@ -59,6 +59,20 @@ describe("useDelegation", () => {
         expect(result.current.selectedDelegationUrl).toEqual(url)
     })
 
+    it("should normalize delegation url protocol casing", async () => {
+        const url = "Https://test.com"
+
+        const { result } = renderHook(() => useDelegation({ setGasPayer }), {
+            wrapper: TestWrapper,
+        })
+
+        await act(async () => {
+            await result.current.setSelectedDelegationUrl(url)
+        })
+
+        expect(result.current.selectedDelegationUrl).toEqual("https://test.com")
+    })
+
     it("should set selected delegation account", async () => {
         const account = {
             ...account1D1,
@@ -104,7 +118,7 @@ describe("useDelegation", () => {
     })
 
     it("using provided URL should automatically set delegation option", async () => {
-        const url = "https://test.com"
+        const url = "Https://test.com"
 
         const { result } = renderHook(() => useDelegation({ setGasPayer, providedUrl: url }), {
             wrapper: TestWrapper,
@@ -112,7 +126,7 @@ describe("useDelegation", () => {
 
         expect(result.current.isDelegated).toBeTruthy()
         expect(result.current.selectedDelegationOption).toEqual(DelegationType.URL)
-        expect(result.current.selectedDelegationUrl).toEqual(url)
+        expect(result.current.selectedDelegationUrl).toEqual("https://test.com")
     })
 
     it("should reset all delegation", async () => {

--- a/src/Hooks/useDelegation/useDelegation.ts
+++ b/src/Hooks/useDelegation/useDelegation.ts
@@ -8,6 +8,7 @@ import {
     selectSelectedAccount,
     useAppSelector,
 } from "~Storage/Redux"
+import { URIUtils } from "~Utils"
 
 type Props = {
     providedUrl?: string
@@ -25,7 +26,8 @@ export const useDelegation = ({ providedUrl, setGasPayer }: Props) => {
     const defaultDelegationUrl = useAppSelector(getDefaultDelegationUrl)
 
     const handleSetSelectedDelegationUrl = useCallback((url: string) => {
-        setSelectedDelegationUrl(url)
+        const normalizedUrl = URIUtils.parseUrlSafe(url) || url
+        setSelectedDelegationUrl(normalizedUrl)
         setSelectedDelegationOption(DelegationType.URL)
         setSelectedDelegationAccount(undefined)
     }, [])

--- a/src/Utils/URIUtils/URIUtils.ts
+++ b/src/Utils/URIUtils/URIUtils.ts
@@ -119,9 +119,10 @@ const convertUriToUrl = (uri: string) => {
 }
 
 function parseUrl(url: string) {
-    if (isHttps(url)) return url
-    if (isHttp(url)) return `http://${url.slice(7)}`
-    return `https://${url}`
+    const trimmedUrl = url.trim()
+    if (isHttps(trimmedUrl)) return `https://${trimmedUrl.slice(8)}`
+    if (isHttp(trimmedUrl)) return `http://${trimmedUrl.slice(7)}`
+    return `https://${trimmedUrl}`
 }
 
 function parseUrlSafe(url: string) {


### PR DESCRIPTION
### Motivation
- Users experienced failures when entering delegation URLs with protocol casing (for example `Https://...`) because the URL parsing logic treated protocols case-sensitively, requiring manual lowercase edits on mobile.

### Description
- Trim and normalize protocol handling in `parseUrl` so input like `Https://test.com` becomes `https://test.com` (`src/Utils/URIUtils/URIUtils.ts`).
- Normalize URLs when setting delegation URLs in the delegation hook by using `URIUtils.parseUrlSafe` before storing the value (`src/Hooks/useDelegation/useDelegation.ts`).
- Add a unit test to cover protocol-casing normalization in `useDelegation` (`src/Hooks/useDelegation/useDelegation.spec.ts`).

### Testing
- Commit hooks ran `eslint --fix` and the task completed successfully. 
- Commit hooks ran `prettier --write` and the task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697769095b2c83329e3181a4b956becb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL parsing to correctly handle HTTP and HTTPS protocols with proper trimming and formatting.
  * Delegation URLs are now consistently normalized with lowercase protocol schemes (e.g., "Https://example.com" becomes "https://example.com").

* **Tests**
  * Added tests verifying URL normalization behavior for delegation URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->