### PR TITLE
Fix notification toggle flashing

### DIFF
--- a/src/Screens/Flows/App/NotificationScreen/NotificationScreen.tsx
+++ b/src/Screens/Flows/App/NotificationScreen/NotificationScreen.tsx
@@ -58,10 +58,14 @@ export const NotificationScreen = () => {
         updateNotificationCenterPrefs,
     } = useNotifications()
 
+    const [updatingCategory, setUpdatingCategory] = useState<string | null>(null)
     const { mutate: updatePrefs, isPending: isUpdatingPrefs } = useMutation({
         mutationKey: ["NOTIFICATION_CENTER", "UPDATE_PREFERENCES"],
         mutationFn: async ({ category, enabled }: { category: string; enabled: boolean }) => {
             await updateNotificationCenterPrefs(category, enabled)
+        },
+        onMutate: ({ category }) => {
+            setUpdatingCategory(category)
         },
         onError: () => {
             Feedback.show({
@@ -71,6 +75,11 @@ export const NotificationScreen = () => {
                 icon: "icon-alert-triangle",
                 duration: 3000,
             })
+        },
+        onSettled: (_, __, variables) => {
+            setUpdatingCategory(current =>
+                current && variables?.category && current === variables.category ? null : current,
+            )
         },
     })
 
@@ -259,7 +268,9 @@ export const NotificationScreen = () => {
                                 onValueChange={toggleNotifCenterPreference(NOTIFICATION_CATEGORIES.NFT_UPDATES)}
                                 value={isNftUpdatesEnabled}
                                 color={itemSwitchColor}
-                                disabled={isUpdatingPrefs}
+                                disabled={
+                                    isUpdatingPrefs && updatingCategory === NOTIFICATION_CATEGORIES.NFT_UPDATES
+                                }
                             />
                             <EnableFeature
                                 title={LL.PUSH_NOTIFICATIONS_STARGATE_REWARDS()}
@@ -267,7 +278,7 @@ export const NotificationScreen = () => {
                                 onValueChange={toggleNotifCenterPreference(NOTIFICATION_CATEGORIES.REWARDS)}
                                 value={isRewardsEnabled}
                                 color={itemSwitchColor}
-                                disabled={isUpdatingPrefs}
+                                disabled={isUpdatingPrefs && updatingCategory === NOTIFICATION_CATEGORIES.REWARDS}
                             />
                         </BaseView>
                     </BaseView>
@@ -291,6 +302,7 @@ export const NotificationScreen = () => {
         isNotificationPermissionEnabled,
         requestNotficationPermission,
         isUpdatingPrefs,
+        updatingCategory,
     ])
     useEffect(() => {
         if (error) {


### PR DESCRIPTION
### Motivation

- Prevent both notification toggles from flashing (opacity change) when updating one preference by scoping the disabled state to only the active category.

### Description

- Added a new `updatingCategory` state (`useState<string | null>`) to track which notification category is currently being updated in `NotificationScreen`.
- Hooked into the `useMutation` lifecycle by adding `onMutate` to set `updatingCategory` and `onSettled` to clear it after the request, while keeping existing error handling intact.
- Updated the `EnableFeature` usages for `NOTIFICATION_CATEGORIES.NFT_UPDATES` and `NOTIFICATION_CATEGORIES.REWARDS` to only set `disabled` when `isUpdatingPrefs` and `updatingCategory` match the specific category, and added `updatingCategory` to the `useMemo` dependency list.
- Modified file: `src/Screens/Flows/App/NotificationScreen/NotificationScreen.tsx`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b69fa1ef083329d8ae1a71ac9a0b4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Notification settings interface enhanced to prevent users from interacting with NFT and Rewards notification switches while their corresponding updates are processing, ensuring system stability and preventing state conflicts during active changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->