### PR TITLE
fix: truncate smart wallet account aliases in selector cards

### DIFF
--- a/src/Components/Reusable/SelectableAccountCard/SelectableAccountCard.tsx
+++ b/src/Components/Reusable/SelectableAccountCard/SelectableAccountCard.tsx
@@ -150,8 +150,8 @@ export const SelectableAccountCard = <TAccountType extends AccountWithDevice | W
                 accessibilityValue={{ text: selected ? "selected" : "not selected" }}>
                 <BaseView flexDirection="row" gap={12} alignItems="center" flex={1}>
                     <AccountIcon account={account} size={32} />
-                    <BaseView flexDirection="column" gap={4}>
-                        <Animated.Text numberOfLines={1} style={textAnimatedStyles}>
+                    <BaseView flexDirection="column" gap={4} style={styles.accountInfoContainer}>
+                        <Animated.Text numberOfLines={1} ellipsizeMode="middle" style={textAnimatedStyles}>
                             {vnsName || account.alias}
                         </Animated.Text>
                         <BaseText typographyFont="caption" color={theme.isDark ? COLORS.GREY_100 : COLORS.GREY_500}>
@@ -210,5 +210,9 @@ const baseStyles = (theme: ColorThemeType) =>
         },
         innerTouchable: {
             borderRadius: 8,
+        },
+        accountInfoContainer: {
+            flex: 1,
+            minWidth: 0,
         },
     })


### PR DESCRIPTION
### Motivation
- Prevent long smart wallet account aliases from overlapping the balance column in account selector cards by truncating them with a middle ellipsis and allowing the alias container to shrink.

### Description
- Add `ellipsizeMode="middle"` to the account alias `Animated.Text` while keeping `numberOfLines={1}` so long aliases show a middle ellipsis.
- Add `accountInfoContainer` style with `flex: 1` and `minWidth: 0` and apply it to the alias container so it can shrink properly in a row layout.
- Changed file: `src/Components/Reusable/SelectableAccountCard/SelectableAccountCard.tsx`.

<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-13 at 15 15 27" src="https://github.com/user-attachments/assets/e23aa78e-2e67-43f1-b089-66416f361f8a" />


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698f15fafb3c83328ef8f2b1fd3467f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account name display to handle long names more gracefully by implementing middle-text truncation with ellipsis in the account selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->