### PR TITLE
fix: reset tab stack to initial screen when pressing tab navigation icon

### DIFF
--- a/src/Navigation/Tabs/TabBar.tsx
+++ b/src/Navigation/Tabs/TabBar.tsx
@@ -1,4 +1,5 @@
 import { BottomTabBarHeightCallbackContext, BottomTabBarProps } from "@react-navigation/bottom-tabs"
+import { CommonActions } from "@react-navigation/native"
 import React, { useContext, useEffect, useMemo } from "react"
 import { StyleSheet, TouchableOpacity } from "react-native"
 import Animated, {
@@ -102,10 +103,12 @@ export const TabBar = ({ state, descriptors, navigation }: Props) => {
 
                         const initialScreen = initialScreenMap[route.name]
 
-                        navigation.navigate({
-                            name: route.name as never,
-                            params: { screen: initialScreen },
-                        })
+                        navigation.dispatch(
+                            CommonActions.navigate({
+                                name: route.name,
+                                params: { screen: initialScreen },
+                            }),
+                        )
                     }
                 }
 

--- a/src/Navigation/Tabs/TabBar.tsx
+++ b/src/Navigation/Tabs/TabBar.tsx
@@ -92,8 +92,20 @@ export const TabBar = ({ state, descriptors, navigation }: Props) => {
                         canPreventDefault: true,
                     })
 
-                    if (!isFocused && !event.defaultPrevented) {
-                        navigation.navigate(route.name, route.params)
+                    if (!event.defaultPrevented) {
+                        const initialScreenMap: Record<string, string> = {
+                            HomeStack: Routes.HOME,
+                            AppsStack: Routes.APPS,
+                            [Routes.HISTORY_STACK]: Routes.HISTORY,
+                            SettingsStack: Routes.SETTINGS,
+                        }
+
+                        const initialScreen = initialScreenMap[route.name]
+
+                        navigation.navigate({
+                            name: route.name as never,
+                            params: { screen: initialScreen },
+                        })
                     }
                 }
 

--- a/src/Screens/Flows/App/WalletManagement/WalletManagementScreen/components/CreateOrImportWalletBottomSheet.tsx
+++ b/src/Screens/Flows/App/WalletManagement/WalletManagementScreen/components/CreateOrImportWalletBottomSheet.tsx
@@ -12,6 +12,8 @@ import { Routes } from "~Navigation"
 import { selectHasOnboarded, selectUserHasSmartWallet, useAppSelector } from "~Storage/Redux"
 import { ImportWalletOptions, SocialWalletOptions } from "./CreateOrImportBottomsheetViews"
 
+const HandleComponent = () => <BaseView p={8} />
+
 type Props = {
     onClose: () => void
     handleOnCreateWallet: () => void
@@ -129,7 +131,7 @@ export const CreateOrImportWalletBottomSheet = React.forwardRef<BottomSheetModal
                 scrollable={false}
                 floating
                 backgroundStyle={styles.rootSheet}
-                handleComponent={() => <BaseView p={8} />}
+                handleComponent={HandleComponent}
                 onDismiss={onDismiss}>
                 <BaseView flexDirection="column" w={100} position="relative">
                     <BaseTouchable style={styles.closeButton} action={onGoBack}>


### PR DESCRIPTION
When pressing a tab navigation icon, the tab's nested stack is now reset to its initial screen. This fixes an issue where pressing the Home tab after closing the browser would return to the browser instead of the home screen, because the navigation state was preserved.

The fix navigates to each stack's initial screen (HOME, APPS, HISTORY, SETTINGS) instead of just navigating to the stack, which preserves the internal navigation state.

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation to ensure consistent behavior when switching between main tabs in the app.

* **Refactor**
  * Minor internal cleanup in the wallet creation/import bottom sheet; no changes to user-facing UI or flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->