### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -146,7 +146,7 @@
     ],
     "lockFileMaintenance": {
         "enabled": true,
-        "schedule": ["before 8am on the first day of the month"],
+        "schedule": ["at 8am on the first day of the month"],
         "groupName": "lockfile maintenance",
         "addLabels": ["lockfile"]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)", ":disableRateLimiting"],
+    "timezone": "Europe/Rome",
+    "schedule": ["before 8am on the first day of the month"],
+    "minimumReleaseAge": "7 days",
+    "labels": ["dependencies"],
+    "prConcurrentLimit": 5,
+    "osvVulnerabilityAlerts": true,
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "addLabels": ["security"],
+        "schedule": ["at any time"],
+        "minimumReleaseAge": "0 days",
+        "prCreation": "immediate"
+    },
+    "packageRules": [
+        {
+            "description": "Batch every non-major routine bump across all managers (npm, cocoapods, gradle, bundler, github-actions) into one monthly PR",
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "groupName": "non-major dependencies",
+            "groupSlug": "non-major"
+        },
+        {
+            "description": "Disable major bumps for React Native core stack — RN major migration is a multi-day project.",
+            "matchPackageNames": [
+                "react",
+                "react-dom",
+                "react-native",
+                "react-test-renderer",
+                "@types/react",
+                "@types/react-test-renderer",
+                "@react-native/babel-preset",
+                "@react-native/eslint-config",
+                "@react-native/metro-config",
+                "@react-native/typescript-config",
+                "@react-native-community/cli",
+                "@react-native-community/cli-platform-android",
+                "@react-native-community/cli-platform-ios"
+            ],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for Expo SDK — tied to RN version, breaking changes per SDK.",
+            "matchPackageNames": ["expo", "/^expo-/", "/^@expo//", "jest-expo"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for React Navigation — v6→v7 is a breaking migration; several packages also patched via patch-package.",
+            "matchPackageNames": ["/^@react-navigation//"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for VeChain SDK + Connex — all pinned to same version family. Manual coordinated migration.",
+            "matchPackageNames": ["/^@vechain//", "thor-devkit"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Group VeChain SDK packages so non-major bumps move together.",
+            "matchPackageNames": ["/^@vechain/sdk-/"],
+            "groupName": "vechain-sdk"
+        },
+        {
+            "description": "Disable major bumps for WalletConnect / Reown stack — pinned to 2.15.2 via package.json resolutions.",
+            "matchPackageNames": ["/^@walletconnect//", "/^@reown//"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Group WalletConnect packages.",
+            "matchPackageNames": ["/^@walletconnect//"],
+            "groupName": "walletconnect"
+        },
+        {
+            "description": "Disable major bumps for Privy SDK — wallet auth stack, breaking API per major.",
+            "matchPackageNames": ["/^@privy-io//"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for ethers — v5 → v6 is a full rewrite. Pinned to v5 across @ethersproject/*.",
+            "matchPackageNames": ["ethers", "/^@ethersproject//"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for Redux Toolkit + react-redux — coordinated migration.",
+            "matchPackageNames": ["@reduxjs/toolkit", "react-redux", "redux-persist"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Group TanStack Query packages — peer-dep coupled.",
+            "matchPackageNames": ["/^@tanstack//"],
+            "groupName": "tanstack-query"
+        },
+        {
+            "description": "Disable major bumps for TanStack Query — breaking API per major.",
+            "matchPackageNames": ["/^@tanstack//"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for TypeScript — strict mode breakage per major.",
+            "matchPackageNames": ["typescript"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for Skia + Reanimated + Gesture Handler + Screens — native modules tied to RN version.",
+            "matchPackageNames": [
+                "@shopify/react-native-skia",
+                "react-native-reanimated",
+                "react-native-gesture-handler",
+                "react-native-screens"
+            ],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable major bumps for patch-package-patched packages — major bump invalidates the patch file.",
+            "matchPackageNames": [
+                "@react-navigation/bottom-tabs",
+                "react-native-draggable-flatlist",
+                "react-native-keyboard-controller",
+                "react-native-mmkv",
+                "react-native-safe-area-context",
+                "react-native-scrypt",
+                "react-native-wagmi-charts",
+                "react-native-webview"
+            ],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "description": "Disable Node base image major bumps in Docker (if introduced). Defensive.",
+            "matchManagers": ["dockerfile"],
+            "matchPackageNames": ["node"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        }
+    ],
+    "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": ["before 8am on the first day of the month"],
+        "groupName": "lockfile maintenance",
+        "addLabels": ["lockfile"]
+    }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", ":semanticCommitTypeAll(chore)", ":disableRateLimiting"],
     "timezone": "Europe/Rome",
-    "schedule": ["before 8am on the first day of the month"],
+    "schedule": ["at 8am on the first day of the month"],
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies"],
     "prConcurrentLimit": 5,

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)", ":disableRateLimiting"],
+    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
     "timezone": "Europe/Rome",
     "schedule": ["at 8am on the first day of the month"],
     "minimumReleaseAge": "7 days",

--- a/renovate.json
+++ b/renovate.json
@@ -43,47 +43,47 @@
         },
         {
             "description": "Disable major bumps for Expo SDK — tied to RN version, breaking changes per SDK.",
-            "matchPackageNames": ["expo", "/^expo-/", "/^@expo//", "jest-expo"],
+            "matchPackageNames": ["expo", "/^expo-/", "/^@expo\\//", "jest-expo"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {
             "description": "Disable major bumps for React Navigation — v6→v7 is a breaking migration; several packages also patched via patch-package.",
-            "matchPackageNames": ["/^@react-navigation//"],
+            "matchPackageNames": ["/^@react-navigation\\//"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {
             "description": "Disable major bumps for VeChain SDK + Connex — all pinned to same version family. Manual coordinated migration.",
-            "matchPackageNames": ["/^@vechain//", "thor-devkit"],
+            "matchPackageNames": ["/^@vechain\\//", "thor-devkit"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {
             "description": "Group VeChain SDK packages so non-major bumps move together.",
-            "matchPackageNames": ["/^@vechain/sdk-/"],
+            "matchPackageNames": ["/^@vechain\\/sdk-/"],
             "groupName": "vechain-sdk"
         },
         {
             "description": "Disable major bumps for WalletConnect / Reown stack — pinned to 2.15.2 via package.json resolutions.",
-            "matchPackageNames": ["/^@walletconnect//", "/^@reown//"],
+            "matchPackageNames": ["/^@walletconnect\\//", "/^@reown\\//"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {
             "description": "Group WalletConnect packages.",
-            "matchPackageNames": ["/^@walletconnect//"],
+            "matchPackageNames": ["/^@walletconnect\\//"],
             "groupName": "walletconnect"
         },
         {
             "description": "Disable major bumps for Privy SDK — wallet auth stack, breaking API per major.",
-            "matchPackageNames": ["/^@privy-io//"],
+            "matchPackageNames": ["/^@privy-io\\//"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {
             "description": "Disable major bumps for ethers — v5 → v6 is a full rewrite. Pinned to v5 across @ethersproject/*.",
-            "matchPackageNames": ["ethers", "/^@ethersproject//"],
+            "matchPackageNames": ["ethers", "/^@ethersproject\\//"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },
@@ -95,12 +95,12 @@
         },
         {
             "description": "Group TanStack Query packages — peer-dep coupled.",
-            "matchPackageNames": ["/^@tanstack//"],
+            "matchPackageNames": ["/^@tanstack\\//"],
             "groupName": "tanstack-query"
         },
         {
             "description": "Disable major bumps for TanStack Query — breaking API per major.",
-            "matchPackageNames": ["/^@tanstack//"],
+            "matchPackageNames": ["/^@tanstack\\//"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },


### PR DESCRIPTION
## Summary

Adds Renovate to split dependency management:

- **Dependabot + Aikido** → primary CVE/security channels (immediate, one PR per advisory). No `dependabot.yml` needed — GitHub Dependabot security updates run from repo Settings → Code security.
- **Renovate** → routine version bumps batched into a single monthly PR (first day of month, 08:00 Europe/Rome, 7-day release-age cooldown).
- Renovate `vulnerabilityAlerts` + `osvVulnerabilityAlerts` enabled as overlapping safety net for OSV advisories GitHub may miss. Occasional duplicate with Dependabot accepted as trade-off.

## Config highlights

- Managers covered: npm, cocoapods, gradle, bundler, github-actions.
- Non-major bumps batched into `non-major dependencies` group.
- Major bumps **disabled** for version-coupled stacks: React Native, Expo, React Navigation, VeChain SDK, WalletConnect/Reown, Privy, ethers (v5), Redux Toolkit, TanStack Query, TypeScript, Skia/Reanimated/Gesture Handler/Screens.
- Major bumps **disabled** for every `patches/*` patch-package target (major bump invalidates the patch).
- Grouped families: `vechain-sdk`, `walletconnect`, `tanstack-query`.
- `lockFileMaintenance` enabled monthly.
- Semantic commit type forced to `chore` (matches commitlint).

## Pre-merge

- [x] `npx renovate-config-validator renovate.json` → `Config validated successfully`
- [x] `security` + `lockfile` labels created

## Post-merge

1. Install Renovate GitHub App on `vechain/veworld-mobile` → https://github.com/apps/renovate.
2. Since `renovate.json` already lives on `main`, the app skips the onboarding PR and runs config directly.
3. Verify `Dependency Dashboard` issue appears within ~1h.
4. First batch PR fires naturally on the next 1st-of-month slot (no manual trigger).
5. Triage existing Dependabot security PRs at human pace (15 open at time of writing).

## Test plan

- [ ] Renovate config validates locally
- [ ] After install: Dependency Dashboard issue created
- [ ] First scheduled run produces a `chore: update non-major dependencies` PR (or no-op if nothing to bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency management configuration with automated monthly update scheduling and vulnerability alert capabilities. Configured specific dependency groups to receive batched updates while restricting major version changes for critical packages including React Native, Expo SDK, React Navigation, and wallet integration libraries. Enabled automatic lockfile maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vechain/veworld-mobile/pull/3895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->