### PR TITLE
fix: route Mixpanel to EU endpoint

### DIFF
--- a/src/Hooks/useValidators/useValidators.ts
+++ b/src/Hooks/useValidators/useValidators.ts
@@ -8,7 +8,7 @@ export const getValidatorsQueryKey = (genesisId: string) => ["validators", genes
 
 /**
  * Get all validators for a network
- * @returns {QueryResult<components["schemas"]["PaginatedResponseValidator"]["data"], Error>}
+ * @returns {QueryResult<components["schemas"]["PaginatedResponseValidatorResponse"]["data"], Error>}
  */
 export const useValidators = () => {
     const network = useAppSelector(selectSelectedNetwork)
@@ -19,7 +19,7 @@ export const useValidators = () => {
         queryFn: async () => {
             let hasNextPage = true
             let page = 0
-            const results: components["schemas"]["PaginatedResponseValidator"]["data"] = []
+            const results: components["schemas"]["PaginatedResponseValidatorResponse"]["data"] = []
 
             while (hasNextPage) {
                 try {

--- a/src/Test/helpers/data/validators.ts
+++ b/src/Test/helpers/data/validators.ts
@@ -1,6 +1,6 @@
 import { components } from "~Generated/indexer/schema"
 
-export const mockedValidators: components["schemas"]["PaginatedResponseValidator"]["data"] = [
+export const mockedValidators: components["schemas"]["PaginatedResponseValidatorResponse"]["data"] = [
     {
         id: "0x1f66de57049ffd2cbc85d7a7ba5d1d76d6937678",
         endorser: "0x288b5361faa4daadd750ce997a9c8cab696994ef",
@@ -8,6 +8,13 @@ export const mockedValidators: components["schemas"]["PaginatedResponseValidator
         status: "ACTIVE",
         vetStaked: 179155283,
         validatorVetStaked: 67185283,
+        delegatorVetStaked: 112000000,
+        queuedVetStaked: 0,
+        validatorQueuedVetStaked: 0,
+        delegatorQueuedVetStaked: 0,
+        validatorExitingVetStaked: 0,
+        delegatorExitingVetStaked: 0,
+        exitingVetStaked: 0,
         cycleEndBlock: 23898240,
         blockProbability: 0.024867,
         blocksPerEpoch: 4.47606,
@@ -39,7 +46,6 @@ export const mockedValidators: components["schemas"]["PaginatedResponseValidator
         percentageOffline: 0,
         offlineBlocks: 0,
         totalRewards: 0,
-        validatorTvlPercentage: 0,
         exitBlock: 0,
         queuePosition: 0,
         availableStartBlock: 0,

--- a/src/Utils/AnalyticsUtils/AnalyticsUtils.ts
+++ b/src/Utils/AnalyticsUtils/AnalyticsUtils.ts
@@ -7,6 +7,8 @@ import { info, warn } from "~Utils/Logger"
 let isInitialized = false
 export let mixpanel: Mixpanel
 
+const MIXPANEL_EU_SERVER_URL = "https://api-eu.mixpanel.com"
+
 export interface AnalyticsProperties {
     [key: string]: unknown
 }
@@ -17,7 +19,7 @@ const initialize = () => {
     if (MIX_PANEL_TOKEN) {
         const trackAutomaticEvents = true
         mixpanel = new Mixpanel(MIX_PANEL_TOKEN as string, trackAutomaticEvents)
-        mixpanel.init()
+        mixpanel.init(false, {}, MIXPANEL_EU_SERVER_URL)
         isInitialized = true
         info(ERROR_EVENTS.APP, "Mixpanel initialized")
     } else {

--- a/src/Utils/ValidatorUtils/ValidatorUtils.ts
+++ b/src/Utils/ValidatorUtils/ValidatorUtils.ts
@@ -24,7 +24,7 @@ export const getValidatorName = (validators: Validator[], address: string): stri
 }
 
 export const getCurrentCycleValidatorStake = (
-    validator: components["schemas"]["PaginatedResponseValidator"]["data"][number],
+    validator: components["schemas"]["PaginatedResponseValidatorResponse"]["data"][number],
 ): number => {
     if (!validator) return 0
     return validator.validatorVetStaked ?? 0


### PR DESCRIPTION
## Summary
- Route Mixpanel React Native SDK traffic to the EU ingestion endpoint during initialization.
- Keep existing analytics token handling, automatic event tracking, and opt-in checks unchanged.

## Test plan
- yarn eslint "src/Utils/AnalyticsUtils/AnalyticsUtils.ts"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated analytics setup to use the EU region endpoint, helping ensure Mixpanel data is sent to the correct server.
  * Made analytics initialization more explicit while keeping tracking behavior unchanged when analytics is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->