### PR TITLE
chore: update macOS dependency installation in workflows

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -35,8 +35,6 @@ jobs:
             # Install Homebrew and applesimutils for Detox
             - name: Install macOS dependencies
               run: |
-                  brew tap wix/brew
-                  brew trust --formula wix/brew/applesimutils
                   brew install wix/brew/applesimutils
                   brew install fastlane
                   bundle install

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -36,7 +36,8 @@ jobs:
             - name: Install macOS dependencies
               run: |
                   brew tap wix/brew
-                  brew install applesimutils
+                  brew trust --formula wix/brew/applesimutils
+                  brew install wix/brew/applesimutils
                   brew install fastlane
                   bundle install
               env:

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -54,8 +54,6 @@ jobs:
             # Install Homebrew and applesimutils for Detox
             - name: Install macOS dependencies
               run: |
-                  brew tap wix/brew
-                  brew trust --formula wix/brew/applesimutils
                   brew install wix/brew/applesimutils
                   brew install fastlane
                   gem install cocoapods # Install CocoaPods globally

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -55,7 +55,8 @@ jobs:
             - name: Install macOS dependencies
               run: |
                   brew tap wix/brew
-                  brew install applesimutils
+                  brew trust --formula wix/brew/applesimutils
+                  brew install wix/brew/applesimutils
                   brew install fastlane
                   gem install cocoapods # Install CocoaPods globally
                   bundle install


### PR DESCRIPTION
Fix CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS CI and release workflow reliability by updating macOS dependency installation to use a trusted Homebrew source.
  * This helps keep simulator-related setup consistent during automated builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->