### PR TITLE
chore: specify Xcode version in iOS release workflow

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -49,14 +49,14 @@ jobs:
                   node-version-file: .nvmrc
                   cache: "yarn"
 
-            - name: Install Node.js dependencies
-              run: |
-                  yarn install:all
-
             - name: Select Xcode 26.2
               run: |
                   sudo xcode-select -s "$DEVELOPER_DIR"
                   xcodebuild -version
+
+            - name: Install Node.js dependencies
+              run: |
+                  yarn install:all
 
             # Install Homebrew and applesimutils for Detox
             - name: Install macOS dependencies

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -28,6 +28,8 @@ jobs:
         name: Build release for iOS
         runs-on: macos-26-xlarge
         environment: ios-release
+        env:
+            DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
 
         # Proceed only if it's either not a release event or it's a pre-release.
         if: ${{ github.event_name != 'release' || (github.event_name == 'release' && github.event.release.prerelease) }}
@@ -50,6 +52,11 @@ jobs:
             - name: Install Node.js dependencies
               run: |
                   yarn install:all
+
+            - name: Select Xcode 26.2
+              run: |
+                  sudo xcode-select -s "$DEVELOPER_DIR"
+                  xcodebuild -version
 
             # Install Homebrew and applesimutils for Detox
             - name: Install macOS dependencies


### PR DESCRIPTION
# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Fix xCode version in CI


# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

# Checklist

-   [ ] Code adheres to project guidelines and conventions.
-   [ ] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS release workflow to use Xcode 26.2 consistently during builds.
  * Added a check to confirm the selected Xcode version before release steps run, helping make iOS releases more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->