### PR TITLE
fix: update android target api level to 36

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,9 @@
       <action android:name="android.media.action.IMAGE_CAPTURE" />
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:allowBackup="false" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:largeHeap="true" android:networkSecurityConfig="@xml/network_security_config" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/BootTheme" tools:ignore="DataExtractionRules">
+  <!-- React Native 0.79 uses onBackPressed for JS BackHandler events. Keep legacy
+       back dispatch on API 36 until React Native supports predictive back. -->
+  <application android:name=".MainApplication" android:allowBackup="false" android:enableOnBackInvokedCallback="false" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:largeHeap="true" android:networkSecurityConfig="@xml/network_security_config" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/BootTheme" tools:ignore="DataExtractionRules">
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:exported="true" android:launchMode="singleTask" android:screenOrientation="portrait" android:windowSoftInputMode="adjustPan" tools:ignore="LockedOrientationActivity,RedundantLabel">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,6 @@
 
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Your base theme customization -->
-         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
     <!-- BootTheme should inherit from Theme.BootSplash or Theme.BootSplash.EdgeToEdge -->
@@ -10,7 +9,6 @@
         <item name="bootSplashBackground">@color/bootsplash_background</item>
         <item name="bootSplashLogo">@drawable/bootsplash_logo</item>
         <item name="postBootSplashTheme">@style/AppTheme</item>
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
         androidXBrowser = "1.8.0"
@@ -14,7 +14,8 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        // API 36 requires a newer AGP than React Native 0.79 supplies.
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         // Pin Kotlin Gradle plugin to the same version required by Compose (Expo SDK 52)
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")


### PR DESCRIPTION
# Related Issue

<!-- Link to the issue in the repository, e.g., Closes #123 or Fixes #456 OR first create an issue before submitting a merge request -->

_No related issue_

# Description of Changes

<!-- Provide a detailed description of the changes made in this pull request. -->

Updated android api level version to 36

# Reviewer(s)

<!-- @mention the person or team responsible for reviewing this pull request. -->

@Doublemme @hughlivingstone

# UI/UX Changes

<!-- If applicable, include a video screen recording or screenshot showcasing the UI/UX changes. -->
<!-- You can attach videos/images directly or provide links here. -->

_No UI changes_

# Checklist

-   [x] Code adheres to project guidelines and conventions.
-   [x] Unit tests, if applicable, are updated and passing.
-   [ ] Documentation, if applicable, has been updated.
-   [ ] UI/UX changes include visuals (video or screenshots).

---

Thank you for contributing! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated Android compatibility for API level 36.
  - Adopted the platform’s default edge-to-edge display behavior, improving support for modern Android layouts.
  - Preserved expected system back-button behavior for the app’s navigation and back actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->